### PR TITLE
reduce CLI help verbosity

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Conjure'
-copyright = u'2009-2016, Özgür Akgün'
+copyright = u'2009-2017, Özgür Akgün'
 author = u'Özgür Akgün'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/conjure-help.html
+++ b/docs/conjure-help.html
@@ -3,7 +3,7 @@
 <tr><td colspan='3'>Conjure: The Automated Constraint Modelling Tool</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>conjure [COMMAND] ... [OPTIONS] </td></tr>
-<tr><td colspan='3' style='padding-left:2ex;'>The command line interface of Conjure takes a command name as the first argument followed by more arguments depending on the command.<br />This help text gives a list of the available commands.<br />For details of a specific command, pass the --help flag after the command name.<br />For example: 'conjure translate-solution --help'</td></tr>
+<tr><td colspan='3' style='padding-left:2ex;'>The command line interface of Conjure takes a command name as the first argument followed by more arguments depending on the command.<br />This help text gives a list of the available commands.<br />For details of a command, pass the --help flag after the command name.<br />For example: 'conjure translate-solution --help'</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>Common flags:</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--help</td><td style='padding-left:2ex;'>Display help message</td></tr>
@@ -13,140 +13,140 @@
 <tr><td colspan='3' style='padding-left:2ex;'>The main act. Given a problem specification in Essence, produce constraint programming models in Essence'.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>Logging &amp; Output:</td></tr>
-<tr><td style='padding-left:2ex; white-space:nowrap;'>-o</td><td style='padding-left:1ex; white-space:nowrap;'>--output-directory=DIR</td><td style='padding-left:2ex;'>Output directory. Generated models will be saved here.<br />Default value: 'conjure-output'</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--numbering-start=INT</td><td style='padding-left:2ex;'>Starting value to output files.<br />Default value: 1</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--smart-filenames</td><td style='padding-left:2ex;'>Use "smart names" for the models.<br />Turned off by default.<br />Caution: With this flag, Conjure will use the answers when producing a filename. It will ignore the order of questions. This will become a problem if anything other than 'f' is used for questions.</td></tr>
+<tr><td style='padding-left:2ex; white-space:nowrap;'>-o</td><td style='padding-left:1ex; white-space:nowrap;'>--output-directory=DIR</td><td style='padding-left:2ex;'>Where to save generated models.<br />Default value: 'conjure-output'</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--numbering-start=INT</td><td style='padding-left:2ex;'>Starting value for output files.<br />Default value: 1</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--smart-filenames</td><td style='padding-left:2ex;'>Use "smart names" for models.<br />Directs Conjure to use the answers when producing a filename and to ignore the order of questions. Only useful if 'f' is used for questions.</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-level=LOGLEVEL</td><td style='padding-left:2ex;'>Log level.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--verbose-trail</td><td style='padding-left:2ex;'>Whether to generate verbose trails or not.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--rewrites-trail</td><td style='padding-left:2ex;'>Whether to generate trails about the applied rewritings or not.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-rule-fails</td><td style='padding-left:2ex;'>Generate logs for rule failures. (Caution: these can be a lot!)</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--verbose-trail</td><td style='padding-left:2ex;'>Generate verbose trails.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--rewrites-trail</td><td style='padding-left:2ex;'>Generate trails about the applied rewritings.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-rule-fails</td><td style='padding-left:2ex;'>Generate logs for rule failures. (Caution: can be a lot!)</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-rule-successes</td><td style='padding-left:2ex;'>Generate logs for rule applications.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-rule-attempts</td><td style='padding-left:2ex;'>Generate logs for rule attempts. (Caution: these can be a lot!)</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-choices</td><td style='padding-left:2ex;'>Store the choices in a way that can be reused be by -al</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Conjure's output can be in multiple formats.<br />    plain : The default<br />    binary: A binary encoding of the Essence output.<br />            It can be read back in by Conjure.<br />    json  : A json encoding of the Essence output,<br />            for tools integrating with Conjure<br />            to avoid parsing textual Essence.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width to use during pretty printing.<br />Default: 120</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-rule-attempts</td><td style='padding-left:2ex;'>Generate logs for rule attempts. (Caution: can be a lot!)</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-choices</td><td style='padding-left:2ex;'>Store the choices in a way that can be reused by -al</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Format to use for output.<br />    plain : default<br />    binary: can be read by Conjure<br />    json  : use to avoid parsing<br /></td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width for pretty printing.<br />Default: 120</td></tr>
 <tr><td colspan='3'>Model generation:</td></tr>
-<tr><td style='padding-left:2ex; white-space:nowrap;'>-q</td><td style='padding-left:1ex; white-space:nowrap;'>--strategy-q=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when selecting the next question to answer. Options: f (for first), i (for interactive), r (for random), x (for all). The letter a (for auto) can be prepended to automatically skip when there is only one option at any point.<br />Default value: f</td></tr>
-<tr><td style='padding-left:2ex; white-space:nowrap;'>-a</td><td style='padding-left:1ex; white-space:nowrap;'>--strategy-a=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when selecting an answer. Same options as strategy-q.<br />Moreover, c (for compact) can be used to pick the most 'compact' option at every decision point.<br />And, s (for sparse) can be used to pick the most 'sparse' option at every decision point. This can be particularly useful for --representations-givens<br /> l (for follow log) tries to pick the given choices as far as possible<br />Default value: ai</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when choosing a representation.<br />Default value: same as --strategy-a</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-finds=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when choosing a representation for a decision variable.<br />Default value: same as --representations</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-givens=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when choosing a representation for a parameter.<br />Default value: s (for sparse)</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-auxiliaries=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when choosing a representation for an auxiliary variable.<br />Default value: same as --representations</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-quantifieds=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when choosing a representation for a quantified variable.<br />Default value: same as --representations</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-cuts=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when choosing a representation for cuts in 'branching on'.<br />Default value: same as --representations-cuts</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--channelling</td><td style='padding-left:2ex;'>Whether to produce channelled models or not.<br />Can be true or false. (true by default)<br />    false: Do not produce channelled models.<br />    true : Produce channelled models.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representation-levels</td><td style='padding-left:2ex;'>Whether to use built-in precedence levels when choosing representations.<br />These levels are used to cut down the number of generated models.<br />Can be true or false. (true by default)</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--seed=INT</td><td style='padding-left:2ex;'>The seed for the random number generator.</td></tr>
+<tr><td style='padding-left:2ex; white-space:nowrap;'>-q</td><td style='padding-left:1ex; white-space:nowrap;'>--strategy-q=STRATEGY</td><td style='padding-left:2ex;'>Strategy for selecting the next question to answer. Options: f (for first), i (for interactive), r (for random), x (for all). Prepend a (for auto) to automatically skip when there is only one option at any point.<br />Default value: f</td></tr>
+<tr><td style='padding-left:2ex; white-space:nowrap;'>-a</td><td style='padding-left:1ex; white-space:nowrap;'>--strategy-a=STRATEGY</td><td style='padding-left:2ex;'>Strategy for selecting an answer. Same options as strategy-q.<br /> c picks the most 'compact' option at every decision point.<br /> s picks the 'sparsest' option at every decision point: useful for --representations-givens<br /> l (for follow log) tries to pick given choices as far as possible<br />Default value: ai</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations=STRATEGY</td><td style='padding-left:2ex;'>Strategy for choosing a representation.<br />Default value: same as --strategy-a</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-finds=STRATEGY</td><td style='padding-left:2ex;'>Strategy for choosing a representation for a decision variable.<br />Default value: same as --representations</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-givens=STRATEGY</td><td style='padding-left:2ex;'>Strategy for choosing a representation for a parameter.<br />Default value: s (for sparse)</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-auxiliaries=STRATEGY</td><td style='padding-left:2ex;'>Strategy for choosing a representation for an auxiliary variable.<br />Default value: same as --representations</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-quantifieds=STRATEGY</td><td style='padding-left:2ex;'>Strategy for choosing a representation for a quantified variable.<br />Default value: same as --representations</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-cuts=STRATEGY</td><td style='padding-left:2ex;'>Strategy for choosing a representation for cuts in 'branching on'.<br />Default value: same as --representations-cuts</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--channelling</td><td style='padding-left:2ex;'>Whether to produce channelled models (true by default).<br /></td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representation-levels</td><td style='padding-left:2ex;'>Whether to use built-in precedence levels when choosing representations. Used to cut down the number of generated models.<br />Default: true</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--seed=INT</td><td style='padding-left:2ex;'>Random number generator seed.</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-models=INT</td><td style='padding-left:2ex;'>Maximum number of models to generate.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--choices=FILE</td><td style='padding-left:2ex;'>Choices to use if possible for -al can either be a eprime file (created by --logChoices), or a json file </td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--choices=FILE</td><td style='padding-left:2ex;'>Choices to use for -al, either an eprime file (created by --log-choices), or a json file.</td></tr>
 <tr><td colspan='3'>General:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Time limit in seconds (real time).</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Limit in seconds of real time.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>conjure translate-parameter [OPTIONS]</td></tr>
-<tr><td colspan='3' style='padding-left:2ex;'>Refinement of parameter files written in Essence for a particular Essence' model.<br />The model needs to be generated by Conjure.</td></tr>
+<tr><td colspan='3' style='padding-left:2ex;'>Refinement of Essence parameter files for a particular Essence' model.<br />The model needs to be generated by Conjure.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>Flags:</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--eprime=FILE</td><td style='padding-left:2ex;'>An Essence' model generated by Conjure.</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--essence-param=FILE</td><td style='padding-left:2ex;'>An Essence parameter for the original problem specification.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--eprime-param=FILE</td><td style='padding-left:2ex;'>An Essence' parameter matching the Essence' model.<br />This field is optional.<br />By default, its value will be 'foo.eprime-param'<br />if the Essence parameter file is named 'foo.param'</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--eprime-param=FILE</td><td style='padding-left:2ex;'>An Essence' parameter matching the Essence' model.<br />Default is 'foo.eprime-param' if the Essence parameter file is named 'foo.param'.</td></tr>
 <tr><td colspan='3'>Logging &amp; Output:</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-level=LOGLEVEL</td><td style='padding-left:2ex;'>Log level.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Conjure's output can be in multiple formats.<br />    plain : The default<br />    binary: A binary encoding of the Essence output.<br />            It can be read back in by Conjure.<br />    json  : A json encoding of the Essence output,<br />            for tools integrating with Conjure<br />            to avoid parsing textual Essence.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width to use during pretty printing.<br />Default: 120</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Format to use for output.<br />    plain : default<br />    binary: can be read by Conjure<br />    json  : use to avoid parsing<br /></td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width for pretty printing.<br />Default: 120</td></tr>
 <tr><td colspan='3'>General:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Time limit in seconds (real time).</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Limit in seconds of real time.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>conjure translate-solution [OPTIONS]</td></tr>
 <tr><td colspan='3' style='padding-left:2ex;'>Translation of solutions back to Essence.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>Flags:</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--eprime=FILE</td><td style='padding-left:2ex;'>An Essence' model generated by Conjure.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--essence-param=FILE</td><td style='padding-left:2ex;'>An Essence parameter for the original problem specification.<br />This field is optional.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--essence-param=FILE</td><td style='padding-left:2ex;'>An Essence parameter for the original problem specification.</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--eprime-solution=FILE</td><td style='padding-left:2ex;'>An Essence' solution for the corresponding Essence' model.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--essence-solution=FILE</td><td style='padding-left:2ex;'>An Essence solution for the original problem specification.<br />This field is optional.<br />By default, its value will be the value of --eprime-solution, with all extensions dropped the extension '.solution' is added instead.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--essence-solution=FILE</td><td style='padding-left:2ex;'>An Essence solution for the original problem specification.<br />By default, its value is the value of --eprime-solution with extensions replaced by '.solution'.</td></tr>
 <tr><td colspan='3'>Logging &amp; Output:</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-level=LOGLEVEL</td><td style='padding-left:2ex;'>Log level.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Conjure's output can be in multiple formats.<br />    plain : The default<br />    binary: A binary encoding of the Essence output.<br />            It can be read back in by Conjure.<br />    json  : A json encoding of the Essence output,<br />            for tools integrating with Conjure<br />            to avoid parsing textual Essence.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width to use during pretty printing.<br />Default: 120</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Format to use for output.<br />    plain : default<br />    binary: can be read by Conjure<br />    json  : use to avoid parsing<br /></td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width for pretty printing.<br />Default: 120</td></tr>
 <tr><td colspan='3'>General:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Time limit in seconds (real time).</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Limit in seconds of real time.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>conjure validate-solution [OPTIONS]</td></tr>
 <tr><td colspan='3' style='padding-left:2ex;'>Validating a solution.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>Flags:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--essence=FILE</td><td style='padding-left:2ex;'>A problem specification in Essence</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--param=FILE</td><td style='padding-left:2ex;'>An Essence parameter.<br />This field is optional.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--solution=FILE</td><td style='padding-left:2ex;'>An Essence solution.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--essence=FILE</td><td style='padding-left:2ex;'>Problem specification in Essence.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--param=FILE</td><td style='padding-left:2ex;'>Essence parameter file.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--solution=FILE</td><td style='padding-left:2ex;'>Essence solution.</td></tr>
 <tr><td colspan='3'>Logging &amp; Output:</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-level=LOGLEVEL</td><td style='padding-left:2ex;'>Log level.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Conjure's output can be in multiple formats.<br />    plain : The default<br />    binary: A binary encoding of the Essence output.<br />            It can be read back in by Conjure.<br />    json  : A json encoding of the Essence output,<br />            for tools integrating with Conjure<br />            to avoid parsing textual Essence.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width to use during pretty printing.<br />Default: 120</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Format to use for output.<br />    plain : default<br />    binary: can be read by Conjure<br />    json  : use to avoid parsing<br /></td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width for pretty printing.<br />Default: 120</td></tr>
 <tr><td colspan='3'>General:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Time limit in seconds (real time).</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Limit in seconds of real time.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>conjure solve [OPTIONS] ESSENCE_FILE [PARAMETER_FILE(s)]</td></tr>
-<tr><td colspan='3' style='padding-left:2ex;'>This is a combined mode, and it is available for convenience.<br />It runs Conjure in the modelling mode followed by parameter translation if required, then Savile Row + Minion to solve, and then solution translation.</td></tr>
+<tr><td colspan='3' style='padding-left:2ex;'>A combined mode for convenience.<br />Runs Conjure in modelling mode followed by parameter translation if required, then Savile Row + Minion to solve, and then solution translation.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>General:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--validate-solutions</td><td style='padding-left:2ex;'>Enable/disable solution validation. Off by default.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Time limit in seconds (real time).</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--number-of-solutions=ITEM</td><td style='padding-left:2ex;'>Number of solutions to find.<br />Pass the string "all" to enumerate all solutions.<br />Default: 1</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--validate-solutions</td><td style='padding-left:2ex;'>Enable solution validation.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Limit in seconds of real time.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--number-of-solutions=ITEM</td><td style='padding-left:2ex;'>Number of solutions to find; "all" enumerates all solutions.<br />Default: 1</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--copy-solutions</td><td style='padding-left:2ex;'>Whether to place a copy of solution(s) next to the Essence file or not.<br />Default: on</td></tr>
 <tr><td colspan='3'>Logging &amp; Output:</td></tr>
-<tr><td style='padding-left:2ex; white-space:nowrap;'>-o</td><td style='padding-left:1ex; white-space:nowrap;'>--output-directory=DIR</td><td style='padding-left:2ex;'>Output directory. Generated models will be saved here.<br />Default value: 'conjure-output'</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--numbering-start=INT</td><td style='padding-left:2ex;'>Starting value to output files.<br />Default value: 1</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--smart-filenames</td><td style='padding-left:2ex;'>Use "smart names" for the models.<br />Turned off by default.<br />Caution: With this flag, Conjure will use the answers when producing a filename. It will ignore the order of questions. This will become a problem if anything other than 'f' is used for questions.</td></tr>
+<tr><td style='padding-left:2ex; white-space:nowrap;'>-o</td><td style='padding-left:1ex; white-space:nowrap;'>--output-directory=DIR</td><td style='padding-left:2ex;'>Where to save generated models.<br />Default value: 'conjure-output'</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--numbering-start=INT</td><td style='padding-left:2ex;'>Starting value for output files.<br />Default value: 1</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--smart-filenames</td><td style='padding-left:2ex;'>Use "smart names" for models.<br />Directs Conjure to use the answers when producing a filename and to ignore the order of questions. Only useful if 'f' is used for questions.</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-level=LOGLEVEL</td><td style='padding-left:2ex;'>Log level.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--verbose-trail</td><td style='padding-left:2ex;'>Whether to generate verbose trails or not.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--rewrites-trail</td><td style='padding-left:2ex;'>Whether to generate trails about the applied rewritings or not.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-rule-fails</td><td style='padding-left:2ex;'>Generate logs for rule failures. (Caution: these can be a lot!)</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--verbose-trail</td><td style='padding-left:2ex;'>Generate verbose trails.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--rewrites-trail</td><td style='padding-left:2ex;'>Generate trails about the applied rewritings.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-rule-fails</td><td style='padding-left:2ex;'>Generate logs for rule failures. (Caution: can be a lot!)</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-rule-successes</td><td style='padding-left:2ex;'>Generate logs for rule applications.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-rule-attempts</td><td style='padding-left:2ex;'>Generate logs for rule attempts. (Caution: these can be a lot!)</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-choices</td><td style='padding-left:2ex;'>Store the choices in a way that can be reused be by -al</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Conjure's output can be in multiple formats.<br />    plain : The default<br />    binary: A binary encoding of the Essence output.<br />            It can be read back in by Conjure.<br />    json  : A json encoding of the Essence output,<br />            for tools integrating with Conjure<br />            to avoid parsing textual Essence.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width to use during pretty printing.<br />Default: 120</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-rule-attempts</td><td style='padding-left:2ex;'>Generate logs for rule attempts. (Caution: can be a lot!)</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-choices</td><td style='padding-left:2ex;'>Store the choices in a way that can be reused by -al</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Format to use for output.<br />    plain : default<br />    binary: can be read by Conjure<br />    json  : use to avoid parsing<br /></td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width for pretty printing.<br />Default: 120</td></tr>
 <tr><td colspan='3'>Model generation:</td></tr>
-<tr><td style='padding-left:2ex; white-space:nowrap;'>-q</td><td style='padding-left:1ex; white-space:nowrap;'>--strategy-q=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when selecting the next question to answer. Options: f (for first), i (for interactive), r (for random), x (for all). The letter a (for auto) can be prepended to automatically skip when there is only one option at any point.<br />Default value: f</td></tr>
-<tr><td style='padding-left:2ex; white-space:nowrap;'>-a</td><td style='padding-left:1ex; white-space:nowrap;'>--strategy-a=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when selecting an answer. Same options as strategy-q.<br />Moreover, c (for compact) can be used to pick the most 'compact' option at every decision point.<br />And, s (for sparse) can be used to pick the most 'sparse' option at every decision point. This can be particularly useful for --representations-givens<br /> l (for follow log) tries to pick the given choices as far as possible<br />Default value: c</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when choosing a representation.<br />Default value: same as --strategy-a</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-finds=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when choosing a representation for a decision variable.<br />Default value: same as --representations</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-givens=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when choosing a representation for a parameter.<br />Default value: s (for sparse)</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-auxiliaries=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when choosing a representation for an auxiliary variable.<br />Default value: same as --representations</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-quantifieds=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when choosing a representation for a quantified variable.<br />Default value: same as --representations</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-cuts=STRATEGY</td><td style='padding-left:2ex;'>Strategy to use when choosing a representation for cuts in 'branching on'.<br />Default value: same as --representations-cuts</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--channelling</td><td style='padding-left:2ex;'>Whether to produce channelled models or not.<br />Can be true or false. (true by default)<br />    false: Do not produce channelled models.<br />    true : Produce channelled models.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representation-levels</td><td style='padding-left:2ex;'>Whether to use built-in precedence levels when choosing representations.<br />These levels are used to cut down the number of generated models.<br />Can be true or false. (true by default)</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--seed=INT</td><td style='padding-left:2ex;'>The seed for the random number generator.</td></tr>
+<tr><td style='padding-left:2ex; white-space:nowrap;'>-q</td><td style='padding-left:1ex; white-space:nowrap;'>--strategy-q=STRATEGY</td><td style='padding-left:2ex;'>Strategy for selecting the next question to answer. Options: f (for first), i (for interactive), r (for random), x (for all). Prepend a (for auto) to automatically skip when there is only one option at any point.<br />Default value: f</td></tr>
+<tr><td style='padding-left:2ex; white-space:nowrap;'>-a</td><td style='padding-left:1ex; white-space:nowrap;'>--strategy-a=STRATEGY</td><td style='padding-left:2ex;'>Strategy for selecting an answer. Same options as strategy-q.<br /> c picks the most 'compact' option at every decision point.<br /> s picks the 'sparsest' option at every decision point: useful for --representations-givens<br /> l (for follow log) tries to pick given choices as far as possible<br />Default value: c</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations=STRATEGY</td><td style='padding-left:2ex;'>Strategy for choosing a representation.<br />Default value: same as --strategy-a</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-finds=STRATEGY</td><td style='padding-left:2ex;'>Strategy for choosing a representation for a decision variable.<br />Default value: same as --representations</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-givens=STRATEGY</td><td style='padding-left:2ex;'>Strategy for choosing a representation for a parameter.<br />Default value: s (for sparse)</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-auxiliaries=STRATEGY</td><td style='padding-left:2ex;'>Strategy for choosing a representation for an auxiliary variable.<br />Default value: same as --representations</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-quantifieds=STRATEGY</td><td style='padding-left:2ex;'>Strategy for choosing a representation for a quantified variable.<br />Default value: same as --representations</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representations-cuts=STRATEGY</td><td style='padding-left:2ex;'>Strategy for choosing a representation for cuts in 'branching on'.<br />Default value: same as --representations-cuts</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--channelling</td><td style='padding-left:2ex;'>Whether to produce channelled models (true by default).<br /></td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--representation-levels</td><td style='padding-left:2ex;'>Whether to use built-in precedence levels when choosing representations. Used to cut down the number of generated models.<br />Default: true</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--seed=INT</td><td style='padding-left:2ex;'>Random number generator seed.</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-models=INT</td><td style='padding-left:2ex;'>Maximum number of models to generate.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--use-existing-models=FILE</td><td style='padding-left:2ex;'>Takes paths of Essence' models generated beforehand.<br />If given, Conjure will skip the modelling phase and use the existing models for solving.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--use-existing-models=FILE</td><td style='padding-left:2ex;'>Paths of Essence' models generated beforehand. If given, Conjure skips the modelling phase and uses existing models for solving.</td></tr>
 <tr><td colspan='3'>Options for other tools:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--savilerow-options=ITEM</td><td style='padding-left:2ex;'>Options to be passed to Savile Row.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--solver-options=ITEM</td><td style='padding-left:2ex;'>Options to be passed to the backend solver.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--solver=ITEM</td><td style='padding-left:2ex;'>Backend solver to use.<br />Possible values: minion/lingeling/minisat<br />Default: minion</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--savilerow-options=ITEM</td><td style='padding-left:2ex;'>Options passed to Savile Row.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--solver-options=ITEM</td><td style='padding-left:2ex;'>Options passed to the backend solver.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--solver=ITEM</td><td style='padding-left:2ex;'>Backend solver. Possible values: minion/lingeling/minisat<br />Default: minion</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>conjure pretty [OPTIONS] FILE</td></tr>
 <tr><td colspan='3' style='padding-left:2ex;'>Pretty print as Essence file to stdout.<br />This mode can be used to view a binary Essence file in textual form.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>Flags:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--normalise-quantified</td><td style='padding-left:2ex;'>Whether to normalise the names of quantified variables or not. Off by default.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--remove-unused</td><td style='padding-left:2ex;'>Whether to remove unused declarations or not. Off by default.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--normalise-quantified</td><td style='padding-left:2ex;'>Normalise the names of quantified variables.</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--remove-unused</td><td style='padding-left:2ex;'>Remove unused declarations.</td></tr>
 <tr><td colspan='3'>Logging &amp; Output:</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-level=LOGLEVEL</td><td style='padding-left:2ex;'>Log level.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Conjure's output can be in multiple formats.<br />    plain : The default<br />    binary: A binary encoding of the Essence output.<br />            It can be read back in by Conjure.<br />    json  : A json encoding of the Essence output,<br />            for tools integrating with Conjure<br />            to avoid parsing textual Essence.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width to use during pretty printing.<br />Default: 120</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Format to use for output.<br />    plain : default<br />    binary: can be read by Conjure<br />    json  : use to avoid parsing<br /></td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width for pretty printing.<br />Default: 120</td></tr>
 <tr><td colspan='3'>General:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Time limit in seconds (real time).</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Limit in seconds of real time.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>conjure diff [OPTIONS] FILE FILE</td></tr>
 <tr><td colspan='3' style='padding-left:2ex;'>Diff on two Essence files. Works on models, parameters, and solutions.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>Logging &amp; Output:</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-level=LOGLEVEL</td><td style='padding-left:2ex;'>Log level.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Conjure's output can be in multiple formats.<br />    plain : The default<br />    binary: A binary encoding of the Essence output.<br />            It can be read back in by Conjure.<br />    json  : A json encoding of the Essence output,<br />            for tools integrating with Conjure<br />            to avoid parsing textual Essence.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width to use during pretty printing.<br />Default: 120</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Format to use for output.<br />    plain : default<br />    binary: can be read by Conjure<br />    json  : use to avoid parsing<br /></td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width for pretty printing.<br />Default: 120</td></tr>
 <tr><td colspan='3'>General:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Time limit in seconds (real time).</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Limit in seconds of real time.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>conjure type-check [OPTIONS] ESSENCE_FILE</td></tr>
 <tr><td colspan='3' style='padding-left:2ex;'>Type-checking a single Essence file.</td></tr>
@@ -154,29 +154,29 @@
 <tr><td colspan='3'>Logging &amp; Output:</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-level=LOGLEVEL</td><td style='padding-left:2ex;'>Log level.</td></tr>
 <tr><td colspan='3'>General:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Time limit in seconds (real time).</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Limit in seconds of real time.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>conjure split [OPTIONS] ESSENCE_FILE</td></tr>
 <tr><td colspan='3' style='padding-left:2ex;'>Split an Essence file to various smaller files. Useful for testing.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>Logging &amp; Output:</td></tr>
-<tr><td style='padding-left:2ex; white-space:nowrap;'>-o</td><td style='padding-left:1ex; white-space:nowrap;'>--output-directory=DIR</td><td style='padding-left:2ex;'>Output directory. Generated models will be saved here.<br />Default value: 'conjure-output'</td></tr>
+<tr><td style='padding-left:2ex; white-space:nowrap;'>-o</td><td style='padding-left:1ex; white-space:nowrap;'>--output-directory=DIR</td><td style='padding-left:2ex;'>Where to save generated models.<br />Default value: 'conjure-output'</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-level=LOGLEVEL</td><td style='padding-left:2ex;'>Log level.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Conjure's output can be in multiple formats.<br />    plain : The default<br />    binary: A binary encoding of the Essence output.<br />            It can be read back in by Conjure.<br />    json  : A json encoding of the Essence output,<br />            for tools integrating with Conjure<br />            to avoid parsing textual Essence.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width to use during pretty printing.<br />Default: 120</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Format to use for output.<br />    plain : default<br />    binary: can be read by Conjure<br />    json  : use to avoid parsing<br /></td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width for pretty printing.<br />Default: 120</td></tr>
 <tr><td colspan='3'>General:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Time limit in seconds (real time).</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Limit in seconds of real time.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>conjure symmetry-detection [OPTIONS] ESSENCE_FILE</td></tr>
 <tr><td colspan='3' style='padding-left:2ex;'>Dump some JSON to be used as input to ferret for symmetry detection.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>Logging &amp; Output:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--json=JSON_FILE</td><td style='padding-left:2ex;'>Output JSON file.<br />By default, its value will be 'foo.essence-json'<br />if the Essence file is named 'foo.essence'</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--json=JSON_FILE</td><td style='padding-left:2ex;'>Output JSON file.<br />Default is 'foo.essence-json'<br />if the Essence file is named 'foo.essence'</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-level=LOGLEVEL</td><td style='padding-left:2ex;'>Log level.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Conjure's output can be in multiple formats.<br />    plain : The default<br />    binary: A binary encoding of the Essence output.<br />            It can be read back in by Conjure.<br />    json  : A json encoding of the Essence output,<br />            for tools integrating with Conjure<br />            to avoid parsing textual Essence.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width to use during pretty printing.<br />Default: 120</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Format to use for output.<br />    plain : default<br />    binary: can be read by Conjure<br />    json  : use to avoid parsing<br /></td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width for pretty printing.<br />Default: 120</td></tr>
 <tr><td colspan='3'>General:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Time limit in seconds (real time).</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Limit in seconds of real time.</td></tr>
 <tr><td colspan='3'>&nbsp;</tr>
 <tr><td colspan='3'>conjure parameter-generator [OPTIONS] ESSENCE_FILE</td></tr>
 <tr><td colspan='3' style='padding-left:2ex;'>Generate an Essence model describing the instances of the problem class defined in the input Essence model.<br />An error will be printed if the model has infinitely many instances.</td></tr>
@@ -184,10 +184,10 @@
 <tr><td colspan='3'>Logging &amp; Output:</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--essence-out=FILE</td><td style='padding-left:2ex;'>Output file path.</td></tr>
 <tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--log-level=LOGLEVEL</td><td style='padding-left:2ex;'>Log level.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Conjure's output can be in multiple formats.<br />    plain : The default<br />    binary: A binary encoding of the Essence output.<br />            It can be read back in by Conjure.<br />    json  : A json encoding of the Essence output,<br />            for tools integrating with Conjure<br />            to avoid parsing textual Essence.</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width to use during pretty printing.<br />Default: 120</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--output-format=FORMAT</td><td style='padding-left:2ex;'>Format to use for output.<br />    plain : default<br />    binary: can be read by Conjure<br />    json  : use to avoid parsing<br /></td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--line-width=INT</td><td style='padding-left:2ex;'>Line width for pretty printing.<br />Default: 120</td></tr>
 <tr><td colspan='3'>General:</td></tr>
-<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Time limit in seconds (real time).</td></tr>
+<tr><td style='padding-left:2ex;'>&nbsp;<td style='padding-left:1ex; white-space:nowrap;'>--limit-time=INT</td><td style='padding-left:2ex;'>Limit in seconds of real time.</td></tr>
 </table>
 </div>
 <br />

--- a/docs/conjure-help.txt
+++ b/docs/conjure-help.txt
@@ -6,8 +6,7 @@
    The command line interface of Conjure takes a command name as the first
    argument followed by more arguments depending on the command.
    This help text gives a list of the available commands.
-   For details of a specific command, pass the --help flag after the command
-   name.
+   For details of a command, pass the --help flag after the command name.
    For example: 'conjure translate-solution --help'
  
  Common flags:
@@ -19,132 +18,99 @@
    programming models in Essence'.
  
  Logging & Output:
-   -o --output-directory=DIR                  Output directory. Generated
-                                              models will be saved here.
+   -o --output-directory=DIR                  Where to save generated models.
                                               Default value: 'conjure-output'
-      --numbering-start=INT                   Starting value to output files.
+      --numbering-start=INT                   Starting value for output files.
                                               Default value: 1
-      --smart-filenames                       Use "smart names" for the
-                                              models.
-                                              Turned off by default.
-                                              Caution: With this flag, Conjure
-                                              will use the answers when
-                                              producing a filename. It will
+      --smart-filenames                       Use "smart names" for models.
+                                              Directs Conjure to use the answers
+                                              when producing a filename and to
                                               ignore the order of questions.
-                                              This will become a problem if
-                                              anything other than 'f' is used
-                                              for questions.
+                                              Only useful if 'f' is used for
+                                              questions.
       --log-level=LOGLEVEL                    Log level.
-      --verbose-trail                         Whether to generate verbose
-                                              trails or not.
-      --rewrites-trail                        Whether to generate trails about
-                                              the applied rewritings or not.
+      --verbose-trail                         Generate verbose trails.
+      --rewrites-trail                        Generate trails about the
+                                              applied rewritings.
       --log-rule-fails                        Generate logs for rule failures.
-                                              (Caution: these can be a lot!)
+                                              (Caution: can be a lot!)
       --log-rule-successes                    Generate logs for rule
                                               applications.
       --log-rule-attempts                     Generate logs for rule attempts.
-                                              (Caution: these can be a lot!)
+                                              (Caution: can be a lot!)
       --log-choices                           Store the choices in a way that
-                                              can be reused be by -al
-      --output-format=FORMAT                  Conjure's output can be in
-                                              multiple formats.
-                                                  plain : The default
-                                                  binary: A binary encoding of
-                                              the Essence output.
-                                                          It can be read back in
-                                              by Conjure.
-                                                  json  : A json encoding of the
-                                              Essence output,
-                                                          for tools integrating
-                                              with Conjure
-                                                          to avoid parsing
-                                              textual Essence.
-      --line-width=INT                        Line width to use during pretty
-                                              printing.
+                                              can be reused by -al
+      --output-format=FORMAT                  Format to use for output.
+                                                  plain : default
+                                                  binary: can be read by Conjure
+                                                  json  : use to avoid parsing
+      --line-width=INT                        Line width for pretty printing.
                                               Default: 120
  Model generation:
-   -q --strategy-q=STRATEGY                   Strategy to use when selecting
-                                              the next question to answer.
-                                              Options: f (for first), i (for
-                                              interactive), r (for random), x
-                                              (for all). The letter a (for auto)
-                                              can be prepended to automatically
-                                              skip when there is only one option
-                                              at any point.
+   -q --strategy-q=STRATEGY                   Strategy for selecting the next
+                                              question to answer. Options: f
+                                              (for first), i (for interactive),
+                                              r (for random), x (for all).
+                                              Prepend a (for auto) to
+                                              automatically skip when there is
+                                              only one option at any point.
                                               Default value: f
-   -a --strategy-a=STRATEGY                   Strategy to use when selecting
-                                              an answer. Same options as
+   -a --strategy-a=STRATEGY                   Strategy for selecting an
+                                              answer. Same options as
                                               strategy-q.
-                                              Moreover, c (for compact) can be
-                                              used to pick the most 'compact'
-                                              option at every decision point.
-                                              And, s (for sparse) can be used to
-                                              pick the most 'sparse' option at
-                                              every decision point. This can be
-                                              particularly useful for
+                                               c picks the most 'compact' option
+                                              at every decision point.
+                                               s picks the 'sparsest' option at
+                                              every decision point: useful for
                                               --representations-givens
                                                l (for follow log) tries to pick
-                                              the given choices as far as
-                                              possible
+                                              given choices as far as possible
                                               Default value: ai
-      --representations=STRATEGY              Strategy to use when choosing a
+      --representations=STRATEGY              Strategy for choosing a
                                               representation.
                                               Default value: same as
                                               --strategy-a
-      --representations-finds=STRATEGY        Strategy to use when choosing a
+      --representations-finds=STRATEGY        Strategy for choosing a
                                               representation for a decision
                                               variable.
                                               Default value: same as
                                               --representations
-      --representations-givens=STRATEGY       Strategy to use when choosing a
+      --representations-givens=STRATEGY       Strategy for choosing a
                                               representation for a parameter.
                                               Default value: s (for sparse)
-      --representations-auxiliaries=STRATEGY  Strategy to use when choosing a
+      --representations-auxiliaries=STRATEGY  Strategy for choosing a
                                               representation for an auxiliary
                                               variable.
                                               Default value: same as
                                               --representations
-      --representations-quantifieds=STRATEGY  Strategy to use when choosing a
+      --representations-quantifieds=STRATEGY  Strategy for choosing a
                                               representation for a quantified
                                               variable.
                                               Default value: same as
                                               --representations
-      --representations-cuts=STRATEGY         Strategy to use when choosing a
+      --representations-cuts=STRATEGY         Strategy for choosing a
                                               representation for cuts in
                                               'branching on'.
                                               Default value: same as
                                               --representations-cuts
       --channelling                           Whether to produce channelled
-                                              models or not.
-                                              Can be true or false. (true by
-                                              default)
-                                                  false: Do not produce
-                                              channelled models.
-                                                  true : Produce channelled
-                                              models.
+                                              models (true by default).
       --representation-levels                 Whether to use built-in
                                               precedence levels when choosing
-                                              representations.
-                                              These levels are used to cut down
+                                              representations. Used to cut down
                                               the number of generated models.
-                                              Can be true or false. (true by
-                                              default)
-      --seed=INT                              The seed for the random number
-                                              generator.
+                                              Default: true
+      --seed=INT                              Random number generator seed.
       --limit-models=INT                      Maximum number of models to
                                               generate.
-      --choices=FILE                          Choices to use if possible for
-                                              -al can either be a eprime file
-                                              (created by --logChoices), or a
-                                              json file
+      --choices=FILE                          Choices to use for -al, either
+                                              an eprime file (created by
+                                              --log-choices), or a json file.
  General:
-      --limit-time=INT                        Time limit in seconds (real
-                                              time).
+      --limit-time=INT                        Limit in seconds of real time.
  
  conjure translate-parameter [OPTIONS]
-   Refinement of parameter files written in Essence for a particular Essence'
-   model.
+   Refinement of Essence parameter files for a particular Essence' model.
    The model needs to be generated by Conjure.
  
  Flags:
@@ -154,32 +120,19 @@
                                               original problem specification.
       --eprime-param=FILE                     An Essence' parameter matching
                                               the Essence' model.
-                                              This field is optional.
-                                              By default, its value will be
-                                              'foo.eprime-param'
-                                              if the Essence parameter file is
-                                              named 'foo.param'
+                                              Default is 'foo.eprime-param' if
+                                              the Essence parameter file is
+                                              named 'foo.param'.
  Logging & Output:
       --log-level=LOGLEVEL                    Log level.
-      --output-format=FORMAT                  Conjure's output can be in
-                                              multiple formats.
-                                                  plain : The default
-                                                  binary: A binary encoding of
-                                              the Essence output.
-                                                          It can be read back in
-                                              by Conjure.
-                                                  json  : A json encoding of the
-                                              Essence output,
-                                                          for tools integrating
-                                              with Conjure
-                                                          to avoid parsing
-                                              textual Essence.
-      --line-width=INT                        Line width to use during pretty
-                                              printing.
+      --output-format=FORMAT                  Format to use for output.
+                                                  plain : default
+                                                  binary: can be read by Conjure
+                                                  json  : use to avoid parsing
+      --line-width=INT                        Line width for pretty printing.
                                               Default: 120
  General:
-      --limit-time=INT                        Time limit in seconds (real
-                                              time).
+      --limit-time=INT                        Limit in seconds of real time.
  
  conjure translate-solution [OPTIONS]
    Translation of solutions back to Essence.
@@ -189,216 +142,155 @@
                                               Conjure.
       --essence-param=FILE                    An Essence parameter for the
                                               original problem specification.
-                                              This field is optional.
       --eprime-solution=FILE                  An Essence' solution for the
                                               corresponding Essence' model.
       --essence-solution=FILE                 An Essence solution for the
                                               original problem specification.
-                                              This field is optional.
-                                              By default, its value will be the
-                                              value of --eprime-solution, with
-                                              all extensions dropped the
-                                              extension '.solution' is added
-                                              instead.
+                                              By default, its value is the value
+                                              of --eprime-solution with
+                                              extensions replaced by
+                                              '.solution'.
  Logging & Output:
       --log-level=LOGLEVEL                    Log level.
-      --output-format=FORMAT                  Conjure's output can be in
-                                              multiple formats.
-                                                  plain : The default
-                                                  binary: A binary encoding of
-                                              the Essence output.
-                                                          It can be read back in
-                                              by Conjure.
-                                                  json  : A json encoding of the
-                                              Essence output,
-                                                          for tools integrating
-                                              with Conjure
-                                                          to avoid parsing
-                                              textual Essence.
-      --line-width=INT                        Line width to use during pretty
-                                              printing.
+      --output-format=FORMAT                  Format to use for output.
+                                                  plain : default
+                                                  binary: can be read by Conjure
+                                                  json  : use to avoid parsing
+      --line-width=INT                        Line width for pretty printing.
                                               Default: 120
  General:
-      --limit-time=INT                        Time limit in seconds (real
-                                              time).
+      --limit-time=INT                        Limit in seconds of real time.
  
  conjure validate-solution [OPTIONS]
    Validating a solution.
  
  Flags:
-      --essence=FILE                          A problem specification in
-                                              Essence
-      --param=FILE                            An Essence parameter.
-                                              This field is optional.
-      --solution=FILE                         An Essence solution.
+      --essence=FILE                          Problem specification in
+                                              Essence.
+      --param=FILE                            Essence parameter file.
+      --solution=FILE                         Essence solution.
  Logging & Output:
       --log-level=LOGLEVEL                    Log level.
-      --output-format=FORMAT                  Conjure's output can be in
-                                              multiple formats.
-                                                  plain : The default
-                                                  binary: A binary encoding of
-                                              the Essence output.
-                                                          It can be read back in
-                                              by Conjure.
-                                                  json  : A json encoding of the
-                                              Essence output,
-                                                          for tools integrating
-                                              with Conjure
-                                                          to avoid parsing
-                                              textual Essence.
-      --line-width=INT                        Line width to use during pretty
-                                              printing.
+      --output-format=FORMAT                  Format to use for output.
+                                                  plain : default
+                                                  binary: can be read by Conjure
+                                                  json  : use to avoid parsing
+      --line-width=INT                        Line width for pretty printing.
                                               Default: 120
  General:
-      --limit-time=INT                        Time limit in seconds (real
-                                              time).
+      --limit-time=INT                        Limit in seconds of real time.
  
  conjure solve [OPTIONS] ESSENCE_FILE [PARAMETER_FILE(s)]
-   This is a combined mode, and it is available for convenience.
-   It runs Conjure in the modelling mode followed by parameter translation if
-   required, then Savile Row + Minion to solve, and then solution translation.
+   A combined mode for convenience.
+   Runs Conjure in modelling mode followed by parameter translation if required,
+   then Savile Row + Minion to solve, and then solution translation.
  
  General:
-      --validate-solutions                    Enable/disable solution
-                                              validation. Off by default.
-      --limit-time=INT                        Time limit in seconds (real
-                                              time).
-      --number-of-solutions=ITEM              Number of solutions to find.
-                                              Pass the string "all" to enumerate
-                                              all solutions.
+      --validate-solutions                    Enable solution validation.
+      --limit-time=INT                        Limit in seconds of real time.
+      --number-of-solutions=ITEM              Number of solutions to find;
+                                              "all" enumerates all solutions.
                                               Default: 1
       --copy-solutions                        Whether to place a copy of
                                               solution(s) next to the Essence
                                               file or not.
                                               Default: on
  Logging & Output:
-   -o --output-directory=DIR                  Output directory. Generated
-                                              models will be saved here.
+   -o --output-directory=DIR                  Where to save generated models.
                                               Default value: 'conjure-output'
-      --numbering-start=INT                   Starting value to output files.
+      --numbering-start=INT                   Starting value for output files.
                                               Default value: 1
-      --smart-filenames                       Use "smart names" for the
-                                              models.
-                                              Turned off by default.
-                                              Caution: With this flag, Conjure
-                                              will use the answers when
-                                              producing a filename. It will
+      --smart-filenames                       Use "smart names" for models.
+                                              Directs Conjure to use the answers
+                                              when producing a filename and to
                                               ignore the order of questions.
-                                              This will become a problem if
-                                              anything other than 'f' is used
-                                              for questions.
+                                              Only useful if 'f' is used for
+                                              questions.
       --log-level=LOGLEVEL                    Log level.
-      --verbose-trail                         Whether to generate verbose
-                                              trails or not.
-      --rewrites-trail                        Whether to generate trails about
-                                              the applied rewritings or not.
+      --verbose-trail                         Generate verbose trails.
+      --rewrites-trail                        Generate trails about the
+                                              applied rewritings.
       --log-rule-fails                        Generate logs for rule failures.
-                                              (Caution: these can be a lot!)
+                                              (Caution: can be a lot!)
       --log-rule-successes                    Generate logs for rule
                                               applications.
       --log-rule-attempts                     Generate logs for rule attempts.
-                                              (Caution: these can be a lot!)
+                                              (Caution: can be a lot!)
       --log-choices                           Store the choices in a way that
-                                              can be reused be by -al
-      --output-format=FORMAT                  Conjure's output can be in
-                                              multiple formats.
-                                                  plain : The default
-                                                  binary: A binary encoding of
-                                              the Essence output.
-                                                          It can be read back in
-                                              by Conjure.
-                                                  json  : A json encoding of the
-                                              Essence output,
-                                                          for tools integrating
-                                              with Conjure
-                                                          to avoid parsing
-                                              textual Essence.
-      --line-width=INT                        Line width to use during pretty
-                                              printing.
+                                              can be reused by -al
+      --output-format=FORMAT                  Format to use for output.
+                                                  plain : default
+                                                  binary: can be read by Conjure
+                                                  json  : use to avoid parsing
+      --line-width=INT                        Line width for pretty printing.
                                               Default: 120
  Model generation:
-   -q --strategy-q=STRATEGY                   Strategy to use when selecting
-                                              the next question to answer.
-                                              Options: f (for first), i (for
-                                              interactive), r (for random), x
-                                              (for all). The letter a (for auto)
-                                              can be prepended to automatically
-                                              skip when there is only one option
-                                              at any point.
+   -q --strategy-q=STRATEGY                   Strategy for selecting the next
+                                              question to answer. Options: f
+                                              (for first), i (for interactive),
+                                              r (for random), x (for all).
+                                              Prepend a (for auto) to
+                                              automatically skip when there is
+                                              only one option at any point.
                                               Default value: f
-   -a --strategy-a=STRATEGY                   Strategy to use when selecting
-                                              an answer. Same options as
+   -a --strategy-a=STRATEGY                   Strategy for selecting an
+                                              answer. Same options as
                                               strategy-q.
-                                              Moreover, c (for compact) can be
-                                              used to pick the most 'compact'
-                                              option at every decision point.
-                                              And, s (for sparse) can be used to
-                                              pick the most 'sparse' option at
-                                              every decision point. This can be
-                                              particularly useful for
+                                               c picks the most 'compact' option
+                                              at every decision point.
+                                               s picks the 'sparsest' option at
+                                              every decision point: useful for
                                               --representations-givens
                                                l (for follow log) tries to pick
-                                              the given choices as far as
-                                              possible
+                                              given choices as far as possible
                                               Default value: c
-      --representations=STRATEGY              Strategy to use when choosing a
+      --representations=STRATEGY              Strategy for choosing a
                                               representation.
                                               Default value: same as
                                               --strategy-a
-      --representations-finds=STRATEGY        Strategy to use when choosing a
+      --representations-finds=STRATEGY        Strategy for choosing a
                                               representation for a decision
                                               variable.
                                               Default value: same as
                                               --representations
-      --representations-givens=STRATEGY       Strategy to use when choosing a
+      --representations-givens=STRATEGY       Strategy for choosing a
                                               representation for a parameter.
                                               Default value: s (for sparse)
-      --representations-auxiliaries=STRATEGY  Strategy to use when choosing a
+      --representations-auxiliaries=STRATEGY  Strategy for choosing a
                                               representation for an auxiliary
                                               variable.
                                               Default value: same as
                                               --representations
-      --representations-quantifieds=STRATEGY  Strategy to use when choosing a
+      --representations-quantifieds=STRATEGY  Strategy for choosing a
                                               representation for a quantified
                                               variable.
                                               Default value: same as
                                               --representations
-      --representations-cuts=STRATEGY         Strategy to use when choosing a
+      --representations-cuts=STRATEGY         Strategy for choosing a
                                               representation for cuts in
                                               'branching on'.
                                               Default value: same as
                                               --representations-cuts
       --channelling                           Whether to produce channelled
-                                              models or not.
-                                              Can be true or false. (true by
-                                              default)
-                                                  false: Do not produce
-                                              channelled models.
-                                                  true : Produce channelled
-                                              models.
+                                              models (true by default).
       --representation-levels                 Whether to use built-in
                                               precedence levels when choosing
-                                              representations.
-                                              These levels are used to cut down
+                                              representations. Used to cut down
                                               the number of generated models.
-                                              Can be true or false. (true by
-                                              default)
-      --seed=INT                              The seed for the random number
-                                              generator.
+                                              Default: true
+      --seed=INT                              Random number generator seed.
       --limit-models=INT                      Maximum number of models to
                                               generate.
-      --use-existing-models=FILE              Takes paths of Essence' models
-                                              generated beforehand.
-                                              If given, Conjure will skip the
-                                              modelling phase and use the
-                                              existing models for solving.
+      --use-existing-models=FILE              Paths of Essence' models
+                                              generated beforehand. If given,
+                                              Conjure skips the modelling phase
+                                              and uses existing models for
+                                              solving.
  Options for other tools:
-      --savilerow-options=ITEM                Options to be passed to Savile
-                                              Row.
-      --solver-options=ITEM                   Options to be passed to the
-                                              backend solver.
-      --solver=ITEM                           Backend solver to use.
-                                              Possible values:
+      --savilerow-options=ITEM                Options passed to Savile Row.
+      --solver-options=ITEM                   Options passed to the backend
+                                              solver.
+      --solver=ITEM                           Backend solver. Possible values:
                                               minion/lingeling/minisat
                                               Default: minion
  
@@ -407,58 +299,33 @@
    This mode can be used to view a binary Essence file in textual form.
  
  Flags:
-      --normalise-quantified                  Whether to normalise the names
-                                              of quantified variables or not.
-                                              Off by default.
-      --remove-unused                         Whether to remove unused
-                                              declarations or not. Off by
-                                              default.
+      --normalise-quantified                  Normalise the names of
+                                              quantified variables.
+      --remove-unused                         Remove unused declarations.
  Logging & Output:
       --log-level=LOGLEVEL                    Log level.
-      --output-format=FORMAT                  Conjure's output can be in
-                                              multiple formats.
-                                                  plain : The default
-                                                  binary: A binary encoding of
-                                              the Essence output.
-                                                          It can be read back in
-                                              by Conjure.
-                                                  json  : A json encoding of the
-                                              Essence output,
-                                                          for tools integrating
-                                              with Conjure
-                                                          to avoid parsing
-                                              textual Essence.
-      --line-width=INT                        Line width to use during pretty
-                                              printing.
+      --output-format=FORMAT                  Format to use for output.
+                                                  plain : default
+                                                  binary: can be read by Conjure
+                                                  json  : use to avoid parsing
+      --line-width=INT                        Line width for pretty printing.
                                               Default: 120
  General:
-      --limit-time=INT                        Time limit in seconds (real
-                                              time).
+      --limit-time=INT                        Limit in seconds of real time.
  
  conjure diff [OPTIONS] FILE FILE
    Diff on two Essence files. Works on models, parameters, and solutions.
  
  Logging & Output:
       --log-level=LOGLEVEL                    Log level.
-      --output-format=FORMAT                  Conjure's output can be in
-                                              multiple formats.
-                                                  plain : The default
-                                                  binary: A binary encoding of
-                                              the Essence output.
-                                                          It can be read back in
-                                              by Conjure.
-                                                  json  : A json encoding of the
-                                              Essence output,
-                                                          for tools integrating
-                                              with Conjure
-                                                          to avoid parsing
-                                              textual Essence.
-      --line-width=INT                        Line width to use during pretty
-                                              printing.
+      --output-format=FORMAT                  Format to use for output.
+                                                  plain : default
+                                                  binary: can be read by Conjure
+                                                  json  : use to avoid parsing
+      --line-width=INT                        Line width for pretty printing.
                                               Default: 120
  General:
-      --limit-time=INT                        Time limit in seconds (real
-                                              time).
+      --limit-time=INT                        Limit in seconds of real time.
  
  conjure type-check [OPTIONS] ESSENCE_FILE
    Type-checking a single Essence file.
@@ -466,66 +333,41 @@
  Logging & Output:
       --log-level=LOGLEVEL                    Log level.
  General:
-      --limit-time=INT                        Time limit in seconds (real
-                                              time).
+      --limit-time=INT                        Limit in seconds of real time.
  
  conjure split [OPTIONS] ESSENCE_FILE
    Split an Essence file to various smaller files. Useful for testing.
  
  Logging & Output:
-   -o --output-directory=DIR                  Output directory. Generated
-                                              models will be saved here.
+   -o --output-directory=DIR                  Where to save generated models.
                                               Default value: 'conjure-output'
       --log-level=LOGLEVEL                    Log level.
-      --output-format=FORMAT                  Conjure's output can be in
-                                              multiple formats.
-                                                  plain : The default
-                                                  binary: A binary encoding of
-                                              the Essence output.
-                                                          It can be read back in
-                                              by Conjure.
-                                                  json  : A json encoding of the
-                                              Essence output,
-                                                          for tools integrating
-                                              with Conjure
-                                                          to avoid parsing
-                                              textual Essence.
-      --line-width=INT                        Line width to use during pretty
-                                              printing.
+      --output-format=FORMAT                  Format to use for output.
+                                                  plain : default
+                                                  binary: can be read by Conjure
+                                                  json  : use to avoid parsing
+      --line-width=INT                        Line width for pretty printing.
                                               Default: 120
  General:
-      --limit-time=INT                        Time limit in seconds (real
-                                              time).
+      --limit-time=INT                        Limit in seconds of real time.
  
  conjure symmetry-detection [OPTIONS] ESSENCE_FILE
    Dump some JSON to be used as input to ferret for symmetry detection.
  
  Logging & Output:
       --json=JSON_FILE                        Output JSON file.
-                                              By default, its value will be
-                                              'foo.essence-json'
+                                              Default is 'foo.essence-json'
                                               if the Essence file is named
                                               'foo.essence'
       --log-level=LOGLEVEL                    Log level.
-      --output-format=FORMAT                  Conjure's output can be in
-                                              multiple formats.
-                                                  plain : The default
-                                                  binary: A binary encoding of
-                                              the Essence output.
-                                                          It can be read back in
-                                              by Conjure.
-                                                  json  : A json encoding of the
-                                              Essence output,
-                                                          for tools integrating
-                                              with Conjure
-                                                          to avoid parsing
-                                              textual Essence.
-      --line-width=INT                        Line width to use during pretty
-                                              printing.
+      --output-format=FORMAT                  Format to use for output.
+                                                  plain : default
+                                                  binary: can be read by Conjure
+                                                  json  : use to avoid parsing
+      --line-width=INT                        Line width for pretty printing.
                                               Default: 120
  General:
-      --limit-time=INT                        Time limit in seconds (real
-                                              time).
+      --limit-time=INT                        Limit in seconds of real time.
  
  conjure parameter-generator [OPTIONS] ESSENCE_FILE
    Generate an Essence model describing the instances of the problem class
@@ -535,23 +377,12 @@
  Logging & Output:
       --essence-out=FILE                      Output file path.
       --log-level=LOGLEVEL                    Log level.
-      --output-format=FORMAT                  Conjure's output can be in
-                                              multiple formats.
-                                                  plain : The default
-                                                  binary: A binary encoding of
-                                              the Essence output.
-                                                          It can be read back in
-                                              by Conjure.
-                                                  json  : A json encoding of the
-                                              Essence output,
-                                                          for tools integrating
-                                              with Conjure
-                                                          to avoid parsing
-                                              textual Essence.
-      --line-width=INT                        Line width to use during pretty
-                                              printing.
+      --output-format=FORMAT                  Format to use for output.
+                                                  plain : default
+                                                  binary: can be read by Conjure
+                                                  json  : use to avoid parsing
+      --line-width=INT                        Line width for pretty printing.
                                               Default: 120
  General:
-      --limit-time=INT                        Time limit in seconds (real
-                                              time).
+      --limit-time=INT                        Limit in seconds of real time.
 

--- a/src/Conjure/UI.hs
+++ b/src/Conjure/UI.hs
@@ -194,25 +194,24 @@ ui = modes
             &= name "o"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Output directory. Generated models will be saved here.\n\
+            &= help "Where to save generated models.\n\
                     \Default value: 'conjure-output'"
         , numberingStart
             = 1
             &= name "numbering-start"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Starting value to output files.\n\
+            &= help "Starting value for output files.\n\
                     \Default value: 1"
         , smartFilenames
             = False
             &= name "smart-filenames"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Use \"smart names\" for the models.\n\
-                    \Turned off by default.\n\
-                    \Caution: With this flag, Conjure will use the answers when producing \
-                    \a filename. It will ignore the order of questions. \
-                    \This will become a problem if anything other than 'f' is used for questions."
+            &= help "Use \"smart names\" for models.\n\
+                    \Directs Conjure to use the answers when producing \
+                    \a filename and to ignore the order of questions. \
+                    \Only useful if 'f' is used for questions."
         , logLevel
             = def
             &= name "log-level"
@@ -224,19 +223,19 @@ ui = modes
             &= name "verbose-trail"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Whether to generate verbose trails or not."
+            &= help "Generate verbose trails."
         , rewritesTrail
             = False
             &= name "rewrites-trail"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Whether to generate trails about the applied rewritings or not."
+            &= help "Generate trails about the applied rewritings."
         , logRuleFails
             = False
             &= name "log-rule-fails"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Generate logs for rule failures. (Caution: these can be a lot!)"
+            &= help "Generate logs for rule failures. (Caution: can be a lot!)"
         , logRuleSuccesses
             = False
             &= name "log-rule-successes"
@@ -248,13 +247,13 @@ ui = modes
             &= name "log-rule-attempts"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Generate logs for rule attempts. (Caution: these can be a lot!)"
+            &= help "Generate logs for rule attempts. (Caution: can be a lot!)"
         , logChoices
             = False
             &= name "log-choices"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Store the choices in a way that can be reused be by -al"
+            &= help "Store the choices in a way that can be reused by -al"
         , strategyQ
             = "f"
             &= typ "STRATEGY"
@@ -262,9 +261,9 @@ ui = modes
             &= name "q"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when selecting the next question to answer. \
+            &= help "Strategy for selecting the next question to answer. \
                     \Options: f (for first), i (for interactive), r (for random), x (for all). \
-                    \The letter a (for auto) can be prepended to automatically skip \
+                    \Prepend a (for auto) to automatically skip \
                     \when there is only one option at any point.\n\
                     \Default value: f"
         , strategyA
@@ -274,13 +273,13 @@ ui = modes
             &= name "a"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when selecting an answer. Same options as strategy-q.\n\
-                    \Moreover, c (for compact) can be used to pick the most 'compact' option \
+            &= help "Strategy for selecting an answer. Same options as strategy-q.\n\
+                    \ c picks the most 'compact' option \
                     \at every decision point.\n\
-                    \And, s (for sparse) can be used to pick the most 'sparse' option \
-                    \at every decision point. \
-                    \This can be particularly useful for --representations-givens\n\
-                    \ l (for follow log) tries to pick the given choices as far as possible\n\
+                    \ s picks the 'sparsest' option \
+                    \at every decision point: \
+                    \useful for --representations-givens\n\
+                    \ l (for follow log) tries to pick given choices as far as possible\n\
                     \Default value: ai"
         , representations
             = Nothing
@@ -288,7 +287,7 @@ ui = modes
             &= name "representations"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when choosing a representation.\n\
+            &= help "Strategy for choosing a representation.\n\
                     \Default value: same as --strategy-a"
         , representationsFinds
             = Nothing
@@ -296,7 +295,7 @@ ui = modes
             &= name "representations-finds"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when choosing a representation for a decision variable.\n\
+            &= help "Strategy for choosing a representation for a decision variable.\n\
                     \Default value: same as --representations"
         , representationsGivens
             = Nothing
@@ -304,7 +303,7 @@ ui = modes
             &= name "representations-givens"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when choosing a representation for a parameter.\n\
+            &= help "Strategy for choosing a representation for a parameter.\n\
                     \Default value: s (for sparse)"
         , representationsAuxiliaries
             = Nothing
@@ -312,7 +311,7 @@ ui = modes
             &= name "representations-auxiliaries"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when choosing a representation for an auxiliary variable.\n\
+            &= help "Strategy for choosing a representation for an auxiliary variable.\n\
                     \Default value: same as --representations"
         , representationsQuantifieds
             = Nothing
@@ -320,7 +319,7 @@ ui = modes
             &= name "representations-quantifieds"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when choosing a representation for a quantified variable.\n\
+            &= help "Strategy for choosing a representation for a quantified variable.\n\
                     \Default value: same as --representations"
         , representationsCuts
             = Nothing
@@ -328,31 +327,29 @@ ui = modes
             &= name "representations-cuts"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when choosing a representation for cuts in 'branching on'.\n\
+            &= help "Strategy for choosing a representation for cuts in 'branching on'.\n\
                     \Default value: same as --representations-cuts"
         , channelling
             = True
             &= name "channelling"
             &= groupname "Model generation"
             &= explicit
-            &= help "Whether to produce channelled models or not.\n\
-                    \Can be true or false. (true by default)\n\
-                    \    false: Do not produce channelled models.\n\
-                    \    true : Produce channelled models."
+            &= help "Whether to produce channelled models \
+                    \(true by default).\n"
         , representationLevels
             = True
             &= name "representation-levels"
             &= groupname "Model generation"
             &= explicit
-            &= help "Whether to use built-in precedence levels when choosing representations.\n\
-                    \These levels are used to cut down the number of generated models.\n\
-                    \Can be true or false. (true by default)"
+            &= help "Whether to use built-in precedence levels when choosing representations. \
+                    \Used to cut down the number of generated models.\n\
+                    \Default: true"
         , seed
             = Nothing
             &= name "seed"
             &= groupname "Model generation"
             &= explicit
-            &= help "The seed for the random number generator."
+            &= help "Random number generator seed."
         , limitModels
             = Nothing
             &= name "limit-models"
@@ -364,34 +361,31 @@ ui = modes
             &= name "limit-time"
             &= groupname "General"
             &= explicit
-            &= help "Time limit in seconds (real time)."
+            &= help "Limit in seconds of real time."
         , savedChoices
             = def
             &= typFile
             &= name "choices"
             &= groupname "Model generation"
             &= explicit
-            &= help "Choices to use if possible for -al \
-                     \can either be a eprime file (created by --logChoices), or a json file "
+            &= help "Choices to use for -al, \
+                     \either an eprime file (created by --log-choices), or a json file."
         , outputFormat
             = def
             &= name "output-format"
             &= groupname "Logging & Output"
             &= explicit
             &= typ "FORMAT"
-            &= help "Conjure's output can be in multiple formats.\n\
-                    \    plain : The default\n\
-                    \    binary: A binary encoding of the Essence output.\n\
-                    \            It can be read back in by Conjure.\n\
-                    \    json  : A json encoding of the Essence output,\n\
-                    \            for tools integrating with Conjure\n\
-                    \            to avoid parsing textual Essence."
+            &= help "Format to use for output.\n\
+                    \    plain : default\n\
+                    \    binary: can be read by Conjure\n\
+                    \    json  : use to avoid parsing\n"
         , lineWidth
             = 120
             &= name "line-width"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Line width to use during pretty printing.\nDefault: 120"
+            &= help "Line width for pretty printing.\nDefault: 120"
         }   &= name "modelling"
             &= explicit
             &= help "The main act. Given a problem specification in Essence, \
@@ -416,9 +410,8 @@ ui = modes
             &= name "eprime-param"
             &= explicit
             &= help "An Essence' parameter matching the Essence' model.\n\
-                    \This field is optional.\n\
-                    \By default, its value will be 'foo.eprime-param'\n\
-                    \if the Essence parameter file is named 'foo.param'"
+                    \Default is 'foo.eprime-param' \
+                    \if the Essence parameter file is named 'foo.param'."
         , logLevel
             = def
             &= name "log-level"
@@ -430,29 +423,26 @@ ui = modes
             &= name "limit-time"
             &= groupname "General"
             &= explicit
-            &= help "Time limit in seconds (real time)."
+            &= help "Limit in seconds of real time."
         , outputFormat
             = def
             &= name "output-format"
             &= groupname "Logging & Output"
             &= explicit
             &= typ "FORMAT"
-            &= help "Conjure's output can be in multiple formats.\n\
-                    \    plain : The default\n\
-                    \    binary: A binary encoding of the Essence output.\n\
-                    \            It can be read back in by Conjure.\n\
-                    \    json  : A json encoding of the Essence output,\n\
-                    \            for tools integrating with Conjure\n\
-                    \            to avoid parsing textual Essence."
+            &= help "Format to use for output.\n\
+                    \    plain : default\n\
+                    \    binary: can be read by Conjure\n\
+                    \    json  : use to avoid parsing\n"
         , lineWidth
             = 120
             &= name "line-width"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Line width to use during pretty printing.\nDefault: 120"
+            &= help "Line width for pretty printing.\nDefault: 120"
         }   &= name "translate-parameter"
             &= explicit
-            &= help "Refinement of parameter files written in Essence for a \
+            &= help "Refinement of Essence parameter files for a \
                     \particular Essence' model.\n\
                     \The model needs to be generated by Conjure."
     , TranslateSolution
@@ -461,14 +451,15 @@ ui = modes
             &= typFile
             &= name "eprime"
             &= explicit
-            &= help "An Essence' model generated by Conjure."
+            &= help "An Essence' model generated by Conjure.\n\
+                     \Mandatory."
         , essenceParamO
             = def
             &= typFile
             &= name "essence-param"
             &= explicit
             &= help "An Essence parameter for the original problem specification.\n\
-                    \This field is optional."
+                     \Mandatory."
         , eprimeSolution
             = def
             &= typFile
@@ -481,9 +472,8 @@ ui = modes
             &= name "essence-solution"
             &= explicit
             &= help "An Essence solution for the original problem specification.\n\
-                    \This field is optional.\n\
-                    \By default, its value will be the value of --eprime-solution, \
-                    \with all extensions dropped the extension '.solution' is added instead."
+                    \By default, its value is the value of --eprime-solution \
+                    \with extensions replaced by '.solution'."
         , logLevel
             = def
             &= name "log-level"
@@ -495,26 +485,23 @@ ui = modes
             &= name "limit-time"
             &= groupname "General"
             &= explicit
-            &= help "Time limit in seconds (real time)."
+            &= help "Limit in seconds of real time."
         , outputFormat
             = def
             &= name "output-format"
             &= groupname "Logging & Output"
             &= explicit
             &= typ "FORMAT"
-            &= help "Conjure's output can be in multiple formats.\n\
-                    \    plain : The default\n\
-                    \    binary: A binary encoding of the Essence output.\n\
-                    \            It can be read back in by Conjure.\n\
-                    \    json  : A json encoding of the Essence output,\n\
-                    \            for tools integrating with Conjure\n\
-                    \            to avoid parsing textual Essence."
+            &= help "Format to use for output.\n\
+                    \    plain : default\n\
+                    \    binary: can be read by Conjure\n\
+                    \    json  : use to avoid parsing\n"
         , lineWidth
             = 120
             &= name "line-width"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Line width to use during pretty printing.\nDefault: 120"
+            &= help "Line width for pretty printing.\nDefault: 120"
         }   &= name "translate-solution"
             &= explicit
             &= help "Translation of solutions back to Essence."
@@ -524,20 +511,19 @@ ui = modes
             &= typFile
             &= name "essence"
             &= explicit
-            &= help "A problem specification in Essence"
+            &= help "Problem specification in Essence."
         , essenceParamO
             = def
             &= typFile
             &= name "param"
             &= explicit
-            &= help "An Essence parameter.\n\
-                    \This field is optional."
+            &= help "Essence parameter file."
         , essenceSolution
             = def
             &= typFile
             &= name "solution"
             &= explicit
-            &= help "An Essence solution."
+            &= help "Essence solution."
         , logLevel
             = def
             &= name "log-level"
@@ -549,26 +535,23 @@ ui = modes
             &= name "limit-time"
             &= groupname "General"
             &= explicit
-            &= help "Time limit in seconds (real time)."
+            &= help "Limit in seconds of real time."
         , outputFormat
             = def
             &= name "output-format"
             &= groupname "Logging & Output"
             &= explicit
             &= typ "FORMAT"
-            &= help "Conjure's output can be in multiple formats.\n\
-                    \    plain : The default\n\
-                    \    binary: A binary encoding of the Essence output.\n\
-                    \            It can be read back in by Conjure.\n\
-                    \    json  : A json encoding of the Essence output,\n\
-                    \            for tools integrating with Conjure\n\
-                    \            to avoid parsing textual Essence."
+            &= help "Format to use for output.\n\
+                    \    plain : default\n\
+                    \    binary: can be read by Conjure\n\
+                    \    json  : use to avoid parsing\n"
         , lineWidth
             = 120
             &= name "line-width"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Line width to use during pretty printing.\nDefault: 120"
+            &= help "Line width for pretty printing.\nDefault: 120"
         }   &= name "validate-solution"
             &= explicit
             &= help "Validating a solution."
@@ -586,7 +569,7 @@ ui = modes
             &= name "validate-solutions"
             &= groupname "General"
             &= explicit
-            &= help "Enable/disable solution validation. Off by default."
+            &= help "Enable solution validation."
         , outputDirectory
             = "conjure-output"
             &= typDir
@@ -594,25 +577,24 @@ ui = modes
             &= name "o"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Output directory. Generated models will be saved here.\n\
+            &= help "Where to save generated models.\n\
                     \Default value: 'conjure-output'"
         , numberingStart
             = 1
             &= name "numbering-start"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Starting value to output files.\n\
+            &= help "Starting value for output files.\n\
                     \Default value: 1"
         , smartFilenames
             = False
             &= name "smart-filenames"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Use \"smart names\" for the models.\n\
-                    \Turned off by default.\n\
-                    \Caution: With this flag, Conjure will use the answers when producing \
-                    \a filename. It will ignore the order of questions. \
-                    \This will become a problem if anything other than 'f' is used for questions."
+            &= help "Use \"smart names\" for models.\n\
+                    \Directs Conjure to use the answers when producing \
+                    \a filename and to ignore the order of questions. \
+                    \Only useful if 'f' is used for questions."
         , logLevel
             = def
             &= name "log-level"
@@ -624,19 +606,19 @@ ui = modes
             &= name "verbose-trail"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Whether to generate verbose trails or not."
+            &= help "Generate verbose trails."
         , rewritesTrail
             = False
             &= name "rewrites-trail"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Whether to generate trails about the applied rewritings or not."
+            &= help "Generate trails about the applied rewritings."
         , logRuleFails
             = False
             &= name "log-rule-fails"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Generate logs for rule failures. (Caution: these can be a lot!)"
+            &= help "Generate logs for rule failures. (Caution: can be a lot!)"
         , logRuleSuccesses
             = False
             &= name "log-rule-successes"
@@ -648,13 +630,13 @@ ui = modes
             &= name "log-rule-attempts"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Generate logs for rule attempts. (Caution: these can be a lot!)"
+            &= help "Generate logs for rule attempts. (Caution: can be a lot!)"
         , logChoices
             = False
             &= name "log-choices"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Store the choices in a way that can be reused be by -al"
+            &= help "Store the choices in a way that can be reused by -al"
         , strategyQ
             = "f"
             &= typ "STRATEGY"
@@ -662,9 +644,9 @@ ui = modes
             &= name "q"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when selecting the next question to answer. \
+            &= help "Strategy for selecting the next question to answer. \
                     \Options: f (for first), i (for interactive), r (for random), x (for all). \
-                    \The letter a (for auto) can be prepended to automatically skip \
+                    \Prepend a (for auto) to automatically skip \
                     \when there is only one option at any point.\n\
                     \Default value: f"
         , strategyA
@@ -674,13 +656,13 @@ ui = modes
             &= name "a"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when selecting an answer. Same options as strategy-q.\n\
-                    \Moreover, c (for compact) can be used to pick the most 'compact' option \
+            &= help "Strategy for selecting an answer. Same options as strategy-q.\n\
+                    \ c picks the most 'compact' option \
                     \at every decision point.\n\
-                    \And, s (for sparse) can be used to pick the most 'sparse' option \
-                    \at every decision point. \
-                    \This can be particularly useful for --representations-givens\n\
-                    \ l (for follow log) tries to pick the given choices as far as possible\n\
+                    \ s picks the 'sparsest' option \
+                    \at every decision point: \
+                    \useful for --representations-givens\n\
+                    \ l (for follow log) tries to pick given choices as far as possible\n\
                     \Default value: c"
         , representations
             = Nothing
@@ -688,7 +670,7 @@ ui = modes
             &= name "representations"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when choosing a representation.\n\
+            &= help "Strategy for choosing a representation.\n\
                     \Default value: same as --strategy-a"
         , representationsFinds
             = Nothing
@@ -696,7 +678,7 @@ ui = modes
             &= name "representations-finds"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when choosing a representation for a decision variable.\n\
+            &= help "Strategy for choosing a representation for a decision variable.\n\
                     \Default value: same as --representations"
         , representationsGivens
             = Nothing
@@ -704,7 +686,7 @@ ui = modes
             &= name "representations-givens"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when choosing a representation for a parameter.\n\
+            &= help "Strategy for choosing a representation for a parameter.\n\
                     \Default value: s (for sparse)"
         , representationsAuxiliaries
             = Nothing
@@ -712,7 +694,7 @@ ui = modes
             &= name "representations-auxiliaries"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when choosing a representation for an auxiliary variable.\n\
+            &= help "Strategy for choosing a representation for an auxiliary variable.\n\
                     \Default value: same as --representations"
         , representationsQuantifieds
             = Nothing
@@ -720,7 +702,7 @@ ui = modes
             &= name "representations-quantifieds"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when choosing a representation for a quantified variable.\n\
+            &= help "Strategy for choosing a representation for a quantified variable.\n\
                     \Default value: same as --representations"
         , representationsCuts
             = Nothing
@@ -728,31 +710,29 @@ ui = modes
             &= name "representations-cuts"
             &= groupname "Model generation"
             &= explicit
-            &= help "Strategy to use when choosing a representation for cuts in 'branching on'.\n\
+            &= help "Strategy for choosing a representation for cuts in 'branching on'.\n\
                     \Default value: same as --representations-cuts"
         , channelling
             = True
             &= name "channelling"
             &= groupname "Model generation"
             &= explicit
-            &= help "Whether to produce channelled models or not.\n\
-                    \Can be true or false. (true by default)\n\
-                    \    false: Do not produce channelled models.\n\
-                    \    true : Produce channelled models."
+            &= help "Whether to produce channelled models \
+                    \(true by default).\n"
         , representationLevels
             = True
             &= name "representation-levels"
             &= groupname "Model generation"
             &= explicit
-            &= help "Whether to use built-in precedence levels when choosing representations.\n\
-                    \These levels are used to cut down the number of generated models.\n\
-                    \Can be true or false. (true by default)"
+            &= help "Whether to use built-in precedence levels when choosing representations. \
+                    \Used to cut down the number of generated models.\n\
+                    \Default: true"
         , seed
             = Nothing
             &= name "seed"
             &= groupname "Model generation"
             &= explicit
-            &= help "The seed for the random number generator."
+            &= help "Random number generator seed."
         , limitModels
             = Nothing
             &= name "limit-models"
@@ -764,33 +744,33 @@ ui = modes
             &= name "limit-time"
             &= groupname "General"
             &= explicit
-            &= help "Time limit in seconds (real time)."
+            &= help "Limit in seconds of real time."
         , useExistingModels
             = []
             &= name "use-existing-models"
             &= groupname "Model generation"
             &= explicit
             &= typFile
-            &= help "Takes paths of Essence' models generated beforehand.\n\
-                    \If given, Conjure will skip the modelling phase and use the existing models for solving."
+            &= help "Paths of Essence' models generated beforehand. \
+                    \If given, Conjure skips the modelling phase and uses existing models for solving."
         , savilerowOptions
             = def
             &= name "savilerow-options"
             &= groupname "Options for other tools"
             &= explicit
-            &= help "Options to be passed to Savile Row."
+            &= help "Options passed to Savile Row."
         , solverOptions
             = def
             &= name "solver-options"
             &= groupname "Options for other tools"
             &= explicit
-            &= help "Options to be passed to the backend solver."
+            &= help "Options passed to the backend solver."
         , solver
             = "minion"
             &= name "solver"
             &= groupname "Options for other tools"
             &= explicit
-            &= help "Backend solver to use.\n\
+            &= help "Backend solver. \
                     \Possible values: minion/lingeling/minisat\n\
                     \Default: minion"
         , nbSolutions
@@ -798,8 +778,8 @@ ui = modes
             &= name "number-of-solutions"
             &= groupname "General"
             &= explicit
-            &= help "Number of solutions to find.\n\
-                    \Pass the string \"all\" to enumerate all solutions.\n\
+            &= help "Number of solutions to find; \
+                    \\"all\" enumerates all solutions.\n\
                     \Default: 1"
         , copySolutions
             = True
@@ -814,23 +794,20 @@ ui = modes
             &= groupname "Logging & Output"
             &= explicit
             &= typ "FORMAT"
-            &= help "Conjure's output can be in multiple formats.\n\
-                    \    plain : The default\n\
-                    \    binary: A binary encoding of the Essence output.\n\
-                    \            It can be read back in by Conjure.\n\
-                    \    json  : A json encoding of the Essence output,\n\
-                    \            for tools integrating with Conjure\n\
-                    \            to avoid parsing textual Essence."
+            &= help "Format to use for output.\n\
+                    \    plain : default\n\
+                    \    binary: can be read by Conjure\n\
+                    \    json  : use to avoid parsing\n"
         , lineWidth
             = 120
             &= name "line-width"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Line width to use during pretty printing.\nDefault: 120"
+            &= help "Line width for pretty printing.\nDefault: 120"
         }   &= name "solve"
             &= explicit
-            &= help "This is a combined mode, and it is available for convenience.\n\
-                    \It runs Conjure in the modelling mode followed by \
+            &= help "A combined mode for convenience.\n\
+                    \Runs Conjure in modelling mode followed by \
                     \parameter translation if required, \
                     \then Savile Row + Minion to solve, and \
                     \then solution translation."
@@ -849,37 +826,34 @@ ui = modes
             = False
             &= name "normalise-quantified"
             &= explicit
-            &= help "Whether to normalise the names of quantified variables or not. Off by default."
+            &= help "Normalise the names of quantified variables."
         , removeUnused
             = False
             &= name "remove-unused"
             &= explicit
-            &= help "Whether to remove unused declarations or not. Off by default."
+            &= help "Remove unused declarations."
         , limitTime
             = Nothing
             &= name "limit-time"
             &= groupname "General"
             &= explicit
-            &= help "Time limit in seconds (real time)."
+            &= help "Limit in seconds of real time."
         , outputFormat
             = def
             &= name "output-format"
             &= groupname "Logging & Output"
             &= explicit
             &= typ "FORMAT"
-            &= help "Conjure's output can be in multiple formats.\n\
-                    \    plain : The default\n\
-                    \    binary: A binary encoding of the Essence output.\n\
-                    \            It can be read back in by Conjure.\n\
-                    \    json  : A json encoding of the Essence output,\n\
-                    \            for tools integrating with Conjure\n\
-                    \            to avoid parsing textual Essence."
+            &= help "Format to use for output.\n\
+                    \    plain : default\n\
+                    \    binary: can be read by Conjure\n\
+                    \    json  : use to avoid parsing\n"
         , lineWidth
             = 120
             &= name "line-width"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Line width to use during pretty printing.\nDefault: 120"
+            &= help "Line width for pretty printing.\nDefault: 120"
         }   &= name "pretty"
             &= explicit
             &= help "Pretty print as Essence file to stdout.\n\
@@ -904,26 +878,23 @@ ui = modes
             &= name "limit-time"
             &= groupname "General"
             &= explicit
-            &= help "Time limit in seconds (real time)."
+            &= help "Limit in seconds of real time."
         , outputFormat
             = def
             &= name "output-format"
             &= groupname "Logging & Output"
             &= explicit
             &= typ "FORMAT"
-            &= help "Conjure's output can be in multiple formats.\n\
-                    \    plain : The default\n\
-                    \    binary: A binary encoding of the Essence output.\n\
-                    \            It can be read back in by Conjure.\n\
-                    \    json  : A json encoding of the Essence output,\n\
-                    \            for tools integrating with Conjure\n\
-                    \            to avoid parsing textual Essence."
+            &= help "Format to use for output.\n\
+                    \    plain : default\n\
+                    \    binary: can be read by Conjure\n\
+                    \    json  : use to avoid parsing\n"
         , lineWidth
             = 120
             &= name "line-width"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Line width to use during pretty printing.\nDefault: 120"
+            &= help "Line width for pretty printing.\nDefault: 120"
         }   &= name "diff"
             &= explicit
             &= help "Diff on two Essence files. Works on models, parameters, and solutions."
@@ -943,7 +914,7 @@ ui = modes
             &= name "limit-time"
             &= groupname "General"
             &= explicit
-            &= help "Time limit in seconds (real time)."
+            &= help "Limit in seconds of real time."
         }   &= name "type-check"
             &= explicit
             &= help "Type-checking a single Essence file."
@@ -959,7 +930,7 @@ ui = modes
             &= name "o"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Output directory. Generated models will be saved here.\n\
+            &= help "Where to save generated models.\n\
                     \Default value: 'conjure-output'"
         , logLevel
             = def
@@ -972,26 +943,23 @@ ui = modes
             &= name "limit-time"
             &= groupname "General"
             &= explicit
-            &= help "Time limit in seconds (real time)."
+            &= help "Limit in seconds of real time."
         , outputFormat
             = def
             &= name "output-format"
             &= groupname "Logging & Output"
             &= explicit
             &= typ "FORMAT"
-            &= help "Conjure's output can be in multiple formats.\n\
-                    \    plain : The default\n\
-                    \    binary: A binary encoding of the Essence output.\n\
-                    \            It can be read back in by Conjure.\n\
-                    \    json  : A json encoding of the Essence output,\n\
-                    \            for tools integrating with Conjure\n\
-                    \            to avoid parsing textual Essence."
+            &= help "Format to use for output.\n\
+                    \    plain : default\n\
+                    \    binary: can be read by Conjure\n\
+                    \    json  : use to avoid parsing\n"
         , lineWidth
             = 120
             &= name "line-width"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Line width to use during pretty printing.\nDefault: 120"
+            &= help "Line width for pretty printing.\nDefault: 120"
         }   &= name "split"
             &= explicit
             &= help "Split an Essence file to various smaller files. Useful for testing."
@@ -1007,7 +975,7 @@ ui = modes
             &= groupname "Logging & Output"
             &= explicit
             &= help "Output JSON file.\n\
-                    \By default, its value will be 'foo.essence-json'\n\
+                    \Default is 'foo.essence-json'\n\
                     \if the Essence file is named 'foo.essence'"
         , logLevel
             = def
@@ -1020,26 +988,23 @@ ui = modes
             &= name "limit-time"
             &= groupname "General"
             &= explicit
-            &= help "Time limit in seconds (real time)."
+            &= help "Limit in seconds of real time."
         , outputFormat
             = def
             &= name "output-format"
             &= groupname "Logging & Output"
             &= explicit
             &= typ "FORMAT"
-            &= help "Conjure's output can be in multiple formats.\n\
-                    \    plain : The default\n\
-                    \    binary: A binary encoding of the Essence output.\n\
-                    \            It can be read back in by Conjure.\n\
-                    \    json  : A json encoding of the Essence output,\n\
-                    \            for tools integrating with Conjure\n\
-                    \            to avoid parsing textual Essence."
+            &= help "Format to use for output.\n\
+                    \    plain : default\n\
+                    \    binary: can be read by Conjure\n\
+                    \    json  : use to avoid parsing\n"
         , lineWidth
             = 120
             &= name "line-width"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Line width to use during pretty printing.\nDefault: 120"
+            &= help "Line width for pretty printing.\nDefault: 120"
         }   &= name "symmetry-detection"
             &= explicit
             &= help "Dump some JSON to be used as input to ferret for symmetry detection."
@@ -1067,26 +1032,23 @@ ui = modes
             &= name "limit-time"
             &= groupname "General"
             &= explicit
-            &= help "Time limit in seconds (real time)."
+            &= help "Limit in seconds of real time."
         , outputFormat
             = def
             &= name "output-format"
             &= groupname "Logging & Output"
             &= explicit
             &= typ "FORMAT"
-            &= help "Conjure's output can be in multiple formats.\n\
-                    \    plain : The default\n\
-                    \    binary: A binary encoding of the Essence output.\n\
-                    \            It can be read back in by Conjure.\n\
-                    \    json  : A json encoding of the Essence output,\n\
-                    \            for tools integrating with Conjure\n\
-                    \            to avoid parsing textual Essence."
+            &= help "Format to use for output.\n\
+                    \    plain : default\n\
+                    \    binary: can be read by Conjure\n\
+                    \    json  : use to avoid parsing\n"
         , lineWidth
             = 120
             &= name "line-width"
             &= groupname "Logging & Output"
             &= explicit
-            &= help "Line width to use during pretty printing.\nDefault: 120"
+            &= help "Line width for pretty printing.\nDefault: 120"
         }   &= name "parameter-generator"
             &= explicit
             &= help "Generate an Essence model describing the instances of the problem class \
@@ -1102,6 +1064,6 @@ ui = modes
            &= help "The command line interface of Conjure takes a command name as the first argument \
                    \followed by more arguments depending on the command.\n\
                    \This help text gives a list of the available commands.\n\
-                   \For details of a specific command, pass the --help flag after the command name.\n\
+                   \For details of a command, pass the --help flag after the command name.\n\
                    \For example: 'conjure translate-solution --help'"
 

--- a/tests/golden/conjure-help.txt
+++ b/tests/golden/conjure-help.txt
@@ -6,7 +6,7 @@ conjure [COMMAND] ... [OPTIONS]
   The command line interface of Conjure takes a command name as the first argument followed by more arguments depending
   on the command.
   This help text gives a list of the available commands.
-  For details of a specific command, pass the --help flag after the command name.
+  For details of a command, pass the --help flag after the command name.
   For example: 'conjure translate-solution --help'
 
 Common flags:
@@ -17,232 +17,190 @@ conjure [modelling] [OPTIONS] ESSENCE_FILE
   The main act. Given a problem specification in Essence, produce constraint programming models in Essence'.
 
 Logging & Output:
-  -o --output-directory=DIR                  Output directory. Generated models will be saved here.
+  -o --output-directory=DIR                  Where to save generated models.
                                              Default value: 'conjure-output'
-     --numbering-start=INT                   Starting value to output files.
+     --numbering-start=INT                   Starting value for output files.
                                              Default value: 1
-     --smart-filenames                       Use "smart names" for the models.
-                                             Turned off by default.
-                                             Caution: With this flag, Conjure will use the answers when producing a
-                                             filename. It will ignore the order of questions. This will become a
-                                             problem if anything other than 'f' is used for questions.
+     --smart-filenames                       Use "smart names" for models.
+                                             Directs Conjure to use the answers when producing a filename and to ignore
+                                             the order of questions. Only useful if 'f' is used for questions.
      --log-level=LOGLEVEL                    Log level.
-     --verbose-trail                         Whether to generate verbose trails or not.
-     --rewrites-trail                        Whether to generate trails about the applied rewritings or not.
-     --log-rule-fails                        Generate logs for rule failures. (Caution: these can be a lot!)
+     --verbose-trail                         Generate verbose trails.
+     --rewrites-trail                        Generate trails about the applied rewritings.
+     --log-rule-fails                        Generate logs for rule failures. (Caution: can be a lot!)
      --log-rule-successes                    Generate logs for rule applications.
-     --log-rule-attempts                     Generate logs for rule attempts. (Caution: these can be a lot!)
-     --log-choices                           Store the choices in a way that can be reused be by -al
-     --output-format=FORMAT                  Conjure's output can be in multiple formats.
-                                                 plain : The default
-                                                 binary: A binary encoding of the Essence output.
-                                                         It can be read back in by Conjure.
-                                                 json  : A json encoding of the Essence output.
-                                                         It can be used by other tools integrating with Conjure
-                                                         in order to avoid having to parse textual Essence.
-     --line-width=INT                        Line width to use during pretty printing.
+     --log-rule-attempts                     Generate logs for rule attempts. (Caution: can be a lot!)
+     --log-choices                           Store the choices in a way that can be reused by -al
+     --output-format=FORMAT                  Format to use for output.
+                                                 plain : default
+                                                 binary: can be read by Conjure
+                                                 json  : use to avoid parsing
+     --line-width=INT                        Line width for pretty printing.
                                              Default: 120
 Model generation:
-  -q --strategy-q=STRATEGY                   Strategy to use when selecting the next question to answer. Options: f
-                                             (for first), i (for interactive), r (for random), x (for all). The letter
-                                             a (for auto) can be prepended to automatically skip when there is only one
-                                             option at any point.
+  -q --strategy-q=STRATEGY                   Strategy for selecting the next question to answer. Options: f (for
+                                             first), i (for interactive), r (for random), x (for all). Prepend a (for
+                                             auto) to automatically skip when there is only one option at any point.
                                              Default value: f
-  -a --strategy-a=STRATEGY                   Strategy to use when selecting an answer. Same options as strategy-q.
-                                             Moreover, c (for compact) can be used to pick the most 'compact' option at
-                                             every decision point.
-                                             And, s (for sparse) can be used to pick the most 'sparse' option at every
-                                             decision point. This can be particularly useful for
+  -a --strategy-a=STRATEGY                   Strategy for selecting an answer. Same options as strategy-q.
+                                              c picks the most 'compact' option at every decision point.
+                                              s picks the 'sparsest' option at every decision point: useful for
                                              --representations-givens
-                                              l (for follow log) tries to pick the given choices as far as possible
+                                              l (for follow log) tries to pick given choices as far as possible
                                              Default value: ai
-     --representations=STRATEGY              Strategy to use when choosing a representation.
+     --representations=STRATEGY              Strategy for choosing a representation.
                                              Default value: same as --strategy-a
-     --representations-finds=STRATEGY        Strategy to use when choosing a representation for a decision variable.
+     --representations-finds=STRATEGY        Strategy for choosing a representation for a decision variable.
                                              Default value: same as --representations
-     --representations-givens=STRATEGY       Strategy to use when choosing a representation for a parameter.
+     --representations-givens=STRATEGY       Strategy for choosing a representation for a parameter.
                                              Default value: s (for sparse)
-     --representations-auxiliaries=STRATEGY  Strategy to use when choosing a representation for an auxiliary
-                                             variable.
+     --representations-auxiliaries=STRATEGY  Strategy for choosing a representation for an auxiliary variable.
                                              Default value: same as --representations
-     --representations-quantifieds=STRATEGY  Strategy to use when choosing a representation for a quantified
-                                             variable.
+     --representations-quantifieds=STRATEGY  Strategy for choosing a representation for a quantified variable.
                                              Default value: same as --representations
-     --representations-cuts=STRATEGY         Strategy to use when choosing a representation for cuts in 'branching
-                                             on'.
+     --representations-cuts=STRATEGY         Strategy for choosing a representation for cuts in 'branching on'.
                                              Default value: same as --representations-cuts
-     --channelling                           Whether to produce channelled models or not.
-                                             Can be true or false. (true by default)
-                                                 false: Do not produce channelled models.
-                                                 true : Produce channelled models.
+     --channelling                           Whether to produce channelled models (true by default).
      --representation-levels                 Whether to use built-in precedence levels when choosing representations.
-                                             These levels are used to cut down the number of generated models.
-                                             Can be true or false. (true by default)
-     --seed=INT                              The seed for the random number generator.
+                                             Used to cut down the number of generated models.
+                                             Default: true
+     --seed=INT                              Random number generator seed.
      --limit-models=INT                      Maximum number of models to generate.
-     --choices=FILE                          Choices to use if possible for -al can either be a eprime file (created
-                                             by --logChoices), or a json file
+     --choices=FILE                          Choices to use for -al, either an eprime file (created by
+                                             --log-choices), or a json file.
 General:
-     --limit-time=INT                        Time limit in seconds (real time).
+     --limit-time=INT                        Limit in seconds of real time.
 
 conjure translate-parameter [OPTIONS]
-  Refinement of parameter files written in Essence for a particular Essence' model.
+  Refinement of Essence parameter files for a particular Essence' model.
   The model needs to be generated by Conjure.
 
 Flags:
      --eprime=FILE                           An Essence' model generated by Conjure.
      --essence-param=FILE                    An Essence parameter for the original problem specification.
      --eprime-param=FILE                     An Essence' parameter matching the Essence' model.
-                                             This field is optional.
-                                             By default, its value will be 'foo.eprime-param'
-                                             if the Essence parameter file is named 'foo.param'
+                                             Default is 'foo.eprime-param' if the Essence parameter file is named
+                                             'foo.param'.
 Logging & Output:
      --log-level=LOGLEVEL                    Log level.
-     --output-format=FORMAT                  Conjure's output can be in multiple formats.
-                                                 plain : The default
-                                                 binary: A binary encoding of the Essence output.
-                                                         It can be read back in by Conjure.
-                                                 json  : A json encoding of the Essence output.
-                                                         It can be used by other tools integrating with Conjure
-                                                         in order to avoid having to parse textual Essence.
-     --line-width=INT                        Line width to use during pretty printing.
+     --output-format=FORMAT                  Format to use for output.
+                                                 plain : default
+                                                 binary: can be read by Conjure
+                                                 json  : use to avoid parsing
+     --line-width=INT                        Line width for pretty printing.
                                              Default: 120
 General:
-     --limit-time=INT                        Time limit in seconds (real time).
+     --limit-time=INT                        Limit in seconds of real time.
 
 conjure translate-solution [OPTIONS]
   Translation of solutions back to Essence.
 
 Flags:
      --eprime=FILE                           An Essence' model generated by Conjure.
+                                             Mandatory.
      --essence-param=FILE                    An Essence parameter for the original problem specification.
-                                             This field is optional.
+                                             Mandatory.
      --eprime-solution=FILE                  An Essence' solution for the corresponding Essence' model.
      --essence-solution=FILE                 An Essence solution for the original problem specification.
-                                             This field is optional.
-                                             By default, its value will be the value of --eprime-solution, with all
-                                             extensions dropped the extension '.solution' is added instead.
+                                             By default, its value is the value of --eprime-solution with extensions
+                                             replaced by '.solution'.
 Logging & Output:
      --log-level=LOGLEVEL                    Log level.
-     --output-format=FORMAT                  Conjure's output can be in multiple formats.
-                                                 plain : The default
-                                                 binary: A binary encoding of the Essence output.
-                                                         It can be read back in by Conjure.
-                                                 json  : A json encoding of the Essence output.
-                                                         It can be used by other tools integrating with Conjure
-                                                         in order to avoid having to parse textual Essence.
-     --line-width=INT                        Line width to use during pretty printing.
+     --output-format=FORMAT                  Format to use for output.
+                                                 plain : default
+                                                 binary: can be read by Conjure
+                                                 json  : use to avoid parsing
+     --line-width=INT                        Line width for pretty printing.
                                              Default: 120
 General:
-     --limit-time=INT                        Time limit in seconds (real time).
+     --limit-time=INT                        Limit in seconds of real time.
 
 conjure validate-solution [OPTIONS]
   Validating a solution.
 
 Flags:
-     --essence=FILE                          A problem specification in Essence
-     --param=FILE                            An Essence parameter.
-                                             This field is optional.
-     --solution=FILE                         An Essence solution.
+     --essence=FILE                          Problem specification in Essence.
+     --param=FILE                            Essence parameter file.
+     --solution=FILE                         Essence solution.
 Logging & Output:
      --log-level=LOGLEVEL                    Log level.
-     --output-format=FORMAT                  Conjure's output can be in multiple formats.
-                                                 plain : The default
-                                                 binary: A binary encoding of the Essence output.
-                                                         It can be read back in by Conjure.
-                                                 json  : A json encoding of the Essence output.
-                                                         It can be used by other tools integrating with Conjure
-                                                         in order to avoid having to parse textual Essence.
-     --line-width=INT                        Line width to use during pretty printing.
+     --output-format=FORMAT                  Format to use for output.
+                                                 plain : default
+                                                 binary: can be read by Conjure
+                                                 json  : use to avoid parsing
+     --line-width=INT                        Line width for pretty printing.
                                              Default: 120
 General:
-     --limit-time=INT                        Time limit in seconds (real time).
+     --limit-time=INT                        Limit in seconds of real time.
 
 conjure solve [OPTIONS] ESSENCE_FILE [PARAMETER_FILE(s)]
-  This is a combined mode, and it is available for convenience.
-  It runs Conjure in the modelling mode followed by parameter translation if required, then Savile Row + Minion to
-  solve, and then solution translation.
+  A combined mode for convenience.
+  Runs Conjure in modelling mode followed by parameter translation if required, then Savile Row + Minion to solve, and
+  then solution translation.
 
 General:
-     --validate-solutions                    Enable/disable solution validation. Off by default.
-     --limit-time=INT                        Time limit in seconds (real time).
-     --number-of-solutions=ITEM              Number of solutions to find.
-                                             Pass the string "all" to enumerate all solutions.
+     --validate-solutions                    Enable solution validation.
+     --limit-time=INT                        Limit in seconds of real time.
+     --number-of-solutions=ITEM              Number of solutions to find; "all" enumerates all solutions.
                                              Default: 1
      --copy-solutions                        Whether to place a copy of solution(s) next to the Essence file or not.
                                              Default: on
 Logging & Output:
-  -o --output-directory=DIR                  Output directory. Generated models will be saved here.
+  -o --output-directory=DIR                  Where to save generated models.
                                              Default value: 'conjure-output'
-     --numbering-start=INT                   Starting value to output files.
+     --numbering-start=INT                   Starting value for output files.
                                              Default value: 1
-     --smart-filenames                       Use "smart names" for the models.
-                                             Turned off by default.
-                                             Caution: With this flag, Conjure will use the answers when producing a
-                                             filename. It will ignore the order of questions. This will become a
-                                             problem if anything other than 'f' is used for questions.
+     --smart-filenames                       Use "smart names" for models.
+                                             Directs Conjure to use the answers when producing a filename and to ignore
+                                             the order of questions. Only useful if 'f' is used for questions.
      --log-level=LOGLEVEL                    Log level.
-     --verbose-trail                         Whether to generate verbose trails or not.
-     --rewrites-trail                        Whether to generate trails about the applied rewritings or not.
-     --log-rule-fails                        Generate logs for rule failures. (Caution: these can be a lot!)
+     --verbose-trail                         Generate verbose trails.
+     --rewrites-trail                        Generate trails about the applied rewritings.
+     --log-rule-fails                        Generate logs for rule failures. (Caution: can be a lot!)
      --log-rule-successes                    Generate logs for rule applications.
-     --log-rule-attempts                     Generate logs for rule attempts. (Caution: these can be a lot!)
-     --log-choices                           Store the choices in a way that can be reused be by -al
-     --output-format=FORMAT                  Conjure's output can be in multiple formats.
-                                                 plain : The default
-                                                 binary: A binary encoding of the Essence output.
-                                                         It can be read back in by Conjure.
-                                                 json  : A json encoding of the Essence output.
-                                                         It can be used by other tools integrating with Conjure
-                                                         in order to avoid having to parse textual Essence.
-     --line-width=INT                        Line width to use during pretty printing.
+     --log-rule-attempts                     Generate logs for rule attempts. (Caution: can be a lot!)
+     --log-choices                           Store the choices in a way that can be reused by -al
+     --output-format=FORMAT                  Format to use for output.
+                                                 plain : default
+                                                 binary: can be read by Conjure
+                                                 json  : use to avoid parsing
+     --line-width=INT                        Line width for pretty printing.
                                              Default: 120
 Model generation:
-  -q --strategy-q=STRATEGY                   Strategy to use when selecting the next question to answer. Options: f
-                                             (for first), i (for interactive), r (for random), x (for all). The letter
-                                             a (for auto) can be prepended to automatically skip when there is only one
-                                             option at any point.
+  -q --strategy-q=STRATEGY                   Strategy for selecting the next question to answer. Options: f (for
+                                             first), i (for interactive), r (for random), x (for all). Prepend a (for
+                                             auto) to automatically skip when there is only one option at any point.
                                              Default value: f
-  -a --strategy-a=STRATEGY                   Strategy to use when selecting an answer. Same options as strategy-q.
-                                             Moreover, c (for compact) can be used to pick the most 'compact' option at
-                                             every decision point.
-                                             And, s (for sparse) can be used to pick the most 'sparse' option at every
-                                             decision point. This can be particularly useful for
+  -a --strategy-a=STRATEGY                   Strategy for selecting an answer. Same options as strategy-q.
+                                              c picks the most 'compact' option at every decision point.
+                                              s picks the 'sparsest' option at every decision point: useful for
                                              --representations-givens
-                                              l (for follow log) tries to pick the given choices as far as possible
+                                              l (for follow log) tries to pick given choices as far as possible
                                              Default value: c
-     --representations=STRATEGY              Strategy to use when choosing a representation.
+     --representations=STRATEGY              Strategy for choosing a representation.
                                              Default value: same as --strategy-a
-     --representations-finds=STRATEGY        Strategy to use when choosing a representation for a decision variable.
+     --representations-finds=STRATEGY        Strategy for choosing a representation for a decision variable.
                                              Default value: same as --representations
-     --representations-givens=STRATEGY       Strategy to use when choosing a representation for a parameter.
+     --representations-givens=STRATEGY       Strategy for choosing a representation for a parameter.
                                              Default value: s (for sparse)
-     --representations-auxiliaries=STRATEGY  Strategy to use when choosing a representation for an auxiliary
-                                             variable.
+     --representations-auxiliaries=STRATEGY  Strategy for choosing a representation for an auxiliary variable.
                                              Default value: same as --representations
-     --representations-quantifieds=STRATEGY  Strategy to use when choosing a representation for a quantified
-                                             variable.
+     --representations-quantifieds=STRATEGY  Strategy for choosing a representation for a quantified variable.
                                              Default value: same as --representations
-     --representations-cuts=STRATEGY         Strategy to use when choosing a representation for cuts in 'branching
-                                             on'.
+     --representations-cuts=STRATEGY         Strategy for choosing a representation for cuts in 'branching on'.
                                              Default value: same as --representations-cuts
-     --channelling                           Whether to produce channelled models or not.
-                                             Can be true or false. (true by default)
-                                                 false: Do not produce channelled models.
-                                                 true : Produce channelled models.
+     --channelling                           Whether to produce channelled models (true by default).
      --representation-levels                 Whether to use built-in precedence levels when choosing representations.
-                                             These levels are used to cut down the number of generated models.
-                                             Can be true or false. (true by default)
-     --seed=INT                              The seed for the random number generator.
+                                             Used to cut down the number of generated models.
+                                             Default: true
+     --seed=INT                              Random number generator seed.
      --limit-models=INT                      Maximum number of models to generate.
-     --use-existing-models=FILE              Takes paths of Essence' models generated beforehand.
-                                             If given, Conjure will skip the modelling phase and use the existing
-                                             models for solving.
+     --use-existing-models=FILE              Paths of Essence' models generated beforehand. If given, Conjure skips
+                                             the modelling phase and uses existing models for solving.
 Options for other tools:
-     --savilerow-options=ITEM                Options to be passed to Savile Row.
-     --solver-options=ITEM                   Options to be passed to the backend solver.
-     --solver=ITEM                           Backend solver to use.
-                                             Possible values: minion/lingeling/minisat
+     --savilerow-options=ITEM                Options passed to Savile Row.
+     --solver-options=ITEM                   Options passed to the backend solver.
+     --solver=ITEM                           Backend solver. Possible values: minion/lingeling/minisat
                                              Default: minion
 
 conjure pretty [OPTIONS] FILE
@@ -250,39 +208,32 @@ conjure pretty [OPTIONS] FILE
   This mode can be used to view a binary Essence file in textual form.
 
 Flags:
-     --normalise-quantified                  Whether to normalise the names of quantified variables or not. Off by
-                                             default.
-     --remove-unused                         Whether to remove unused declarations or not. Off by default.
+     --normalise-quantified                  Normalise the names of quantified variables.
+     --remove-unused                         Remove unused declarations.
 Logging & Output:
      --log-level=LOGLEVEL                    Log level.
-     --output-format=FORMAT                  Conjure's output can be in multiple formats.
-                                                 plain : The default
-                                                 binary: A binary encoding of the Essence output.
-                                                         It can be read back in by Conjure.
-                                                 json  : A json encoding of the Essence output.
-                                                         It can be used by other tools integrating with Conjure
-                                                         in order to avoid having to parse textual Essence.
-     --line-width=INT                        Line width to use during pretty printing.
+     --output-format=FORMAT                  Format to use for output.
+                                                 plain : default
+                                                 binary: can be read by Conjure
+                                                 json  : use to avoid parsing
+     --line-width=INT                        Line width for pretty printing.
                                              Default: 120
 General:
-     --limit-time=INT                        Time limit in seconds (real time).
+     --limit-time=INT                        Limit in seconds of real time.
 
 conjure diff [OPTIONS] FILE FILE
   Diff on two Essence files. Works on models, parameters, and solutions.
 
 Logging & Output:
      --log-level=LOGLEVEL                    Log level.
-     --output-format=FORMAT                  Conjure's output can be in multiple formats.
-                                                 plain : The default
-                                                 binary: A binary encoding of the Essence output.
-                                                         It can be read back in by Conjure.
-                                                 json  : A json encoding of the Essence output.
-                                                         It can be used by other tools integrating with Conjure
-                                                         in order to avoid having to parse textual Essence.
-     --line-width=INT                        Line width to use during pretty printing.
+     --output-format=FORMAT                  Format to use for output.
+                                                 plain : default
+                                                 binary: can be read by Conjure
+                                                 json  : use to avoid parsing
+     --line-width=INT                        Line width for pretty printing.
                                              Default: 120
 General:
-     --limit-time=INT                        Time limit in seconds (real time).
+     --limit-time=INT                        Limit in seconds of real time.
 
 conjure type-check [OPTIONS] ESSENCE_FILE
   Type-checking a single Essence file.
@@ -290,46 +241,40 @@ conjure type-check [OPTIONS] ESSENCE_FILE
 Logging & Output:
      --log-level=LOGLEVEL                    Log level.
 General:
-     --limit-time=INT                        Time limit in seconds (real time).
+     --limit-time=INT                        Limit in seconds of real time.
 
 conjure split [OPTIONS] ESSENCE_FILE
   Split an Essence file to various smaller files. Useful for testing.
 
 Logging & Output:
-  -o --output-directory=DIR                  Output directory. Generated models will be saved here.
+  -o --output-directory=DIR                  Where to save generated models.
                                              Default value: 'conjure-output'
      --log-level=LOGLEVEL                    Log level.
-     --output-format=FORMAT                  Conjure's output can be in multiple formats.
-                                                 plain : The default
-                                                 binary: A binary encoding of the Essence output.
-                                                         It can be read back in by Conjure.
-                                                 json  : A json encoding of the Essence output.
-                                                         It can be used by other tools integrating with Conjure
-                                                         in order to avoid having to parse textual Essence.
-     --line-width=INT                        Line width to use during pretty printing.
+     --output-format=FORMAT                  Format to use for output.
+                                                 plain : default
+                                                 binary: can be read by Conjure
+                                                 json  : use to avoid parsing
+     --line-width=INT                        Line width for pretty printing.
                                              Default: 120
 General:
-     --limit-time=INT                        Time limit in seconds (real time).
+     --limit-time=INT                        Limit in seconds of real time.
 
 conjure symmetry-detection [OPTIONS] ESSENCE_FILE
   Dump some JSON to be used as input to ferret for symmetry detection.
 
 Logging & Output:
      --json=JSON_FILE                        Output JSON file.
-                                             By default, its value will be 'foo.essence-json'
+                                             Default is 'foo.essence-json'
                                              if the Essence file is named 'foo.essence'
      --log-level=LOGLEVEL                    Log level.
-     --output-format=FORMAT                  Conjure's output can be in multiple formats.
-                                                 plain : The default
-                                                 binary: A binary encoding of the Essence output.
-                                                         It can be read back in by Conjure.
-                                                 json  : A json encoding of the Essence output.
-                                                         It can be used by other tools integrating with Conjure
-                                                         in order to avoid having to parse textual Essence.
-     --line-width=INT                        Line width to use during pretty printing.
+     --output-format=FORMAT                  Format to use for output.
+                                                 plain : default
+                                                 binary: can be read by Conjure
+                                                 json  : use to avoid parsing
+     --line-width=INT                        Line width for pretty printing.
                                              Default: 120
 General:
-     --limit-time=INT                        Time limit in seconds (real time).
+     --limit-time=INT                        Limit in seconds of real time.
 
 conjure parameter-generator [OPTIONS] ESSENCE_FILE
   Generate an Essence model describing the instances of the problem class defined in the input Essence model.
@@ -338,14 +283,11 @@ conjure parameter-generator [OPTIONS] ESSENCE_FILE
 Logging & Output:
      --essence-out=FILE                      Output file path.
      --log-level=LOGLEVEL                    Log level.
-     --output-format=FORMAT                  Conjure's output can be in multiple formats.
-                                                 plain : The default
-                                                 binary: A binary encoding of the Essence output.
-                                                         It can be read back in by Conjure.
-                                                 json  : A json encoding of the Essence output.
-                                                         It can be used by other tools integrating with Conjure
-                                                         in order to avoid having to parse textual Essence.
-     --line-width=INT                        Line width to use during pretty printing.
+     --output-format=FORMAT                  Format to use for output.
+                                                 plain : default
+                                                 binary: can be read by Conjure
+                                                 json  : use to avoid parsing
+     --line-width=INT                        Line width for pretty printing.
                                              Default: 120
 General:
-     --limit-time=INT                        Time limit in seconds (real time).
+     --limit-time=INT                        Limit in seconds of real time.


### PR DESCRIPTION
Branching this as it is quite a big source change.

This cuts the amount of text printed by the CLI help facility, while (hopefully) retaining the meaning.