### PR TITLE
Same size attributes are merged instead of failing

### DIFF
--- a/src/Conjure/Language/Domain/AddAttributes.hs
+++ b/src/Conjure/Language/Domain/AddAttributes.hs
@@ -482,29 +482,49 @@ addAttributeToDomain domain@(DomainPartition r partitionAttr inner) = updater wh
         AttrName_minPartSize -> do
             let fails = fail $ "Cannot add a minPartSize attribute to this domain:" <++> pretty domain
             case partsSize partitionAttr of
-                SizeAttr_Size s | val == s -> return domain
-                SizeAttr_Size{}       -> fails
-                SizeAttr_MinSize{}    -> fails
-                SizeAttr_MinMaxSize{} -> fails
-                SizeAttr_None{}       -> return $ DomainPartition r
-                                            (partitionAttr { partsSize = SizeAttr_MinSize val })
-                                            inner
-                SizeAttr_MaxSize maxS -> return $ DomainPartition r
-                                            (partitionAttr { partsSize = SizeAttr_MinMaxSize val maxS })
-                                            inner
+                SizeAttr_Size s | val == s    -> return domain
+                SizeAttr_Size{}               -> fails
+                SizeAttr_MinSize minS         -> return $ DomainPartition r
+                                                 partitionAttr { partsSize = SizeAttr_MinSize (mkMax minS val) }
+                                                 inner
+                SizeAttr_MaxSize maxS      | val == maxS -> return $ DomainPartition r
+                                                            partitionAttr { partsSize = SizeAttr_Size val }
+                                                            inner
+                SizeAttr_MaxSize maxS         -> return $ DomainPartition r
+                                                 partitionAttr { partsSize = SizeAttr_MinMaxSize val maxS }
+                                                 inner
+                SizeAttr_MinMaxSize _ maxS | val == maxS -> return $ DomainPartition r
+                                                            partitionAttr { partsSize = SizeAttr_Size val }
+                                                            inner
+                SizeAttr_MinMaxSize minS maxS -> return $ DomainPartition r
+                                                 partitionAttr { partsSize = SizeAttr_MinMaxSize (mkMax minS val) maxS }
+                                                 inner
+                SizeAttr_None{}               -> return $ DomainPartition r
+                                                 (partitionAttr { partsSize = SizeAttr_MinSize val })
+                                                 inner
         AttrName_maxPartSize -> do
             let fails = fail $ "Cannot add a maxPartSize attribute to this domain:" <++> pretty domain
             case partsSize partitionAttr of
-                SizeAttr_Size s | val == s -> return domain
-                SizeAttr_Size{}       -> fails
-                SizeAttr_MaxSize{}    -> fails
-                SizeAttr_MinMaxSize{} -> fails
-                SizeAttr_None{}       -> return $ DomainPartition r
-                                            (partitionAttr { partsSize = SizeAttr_MaxSize val })
-                                            inner
-                SizeAttr_MinSize minS -> return $ DomainPartition r
-                                            (partitionAttr { partsSize = SizeAttr_MinMaxSize minS val })
-                                            inner
+                SizeAttr_Size s | val == s    -> return domain
+                SizeAttr_Size{}               -> fails
+                SizeAttr_MinSize minS      | val == minS -> return $ DomainPartition r
+                                                            partitionAttr { partsSize = SizeAttr_Size val }
+                                                            inner
+                SizeAttr_MinSize minS         -> return $ DomainPartition r
+                                                 partitionAttr { partsSize = SizeAttr_MinMaxSize minS val }
+                                                 inner
+                SizeAttr_MaxSize maxS         -> return $ DomainPartition r
+                                                 partitionAttr { partsSize = SizeAttr_MaxSize (mkMin maxS val) }
+                                                 inner
+                SizeAttr_MinMaxSize minS _ | val == minS -> return $ DomainPartition r
+                                                            partitionAttr { partsSize = SizeAttr_Size val }
+                                                            inner
+                SizeAttr_MinMaxSize minS maxS -> return $ DomainPartition r
+                                                 partitionAttr { partsSize = SizeAttr_MinMaxSize minS (mkMin maxS val) }
+                                                 inner
+                SizeAttr_None{}               -> return $ DomainPartition r
+                                                 (partitionAttr { partsSize = SizeAttr_MaxSize val })
+                                                 inner
 
         _ ->
             fail $ vcat [ "Unsupported attribute" <+> pretty attr

--- a/src/Conjure/Language/Domain/AddAttributes.hs
+++ b/src/Conjure/Language/Domain/AddAttributes.hs
@@ -94,25 +94,25 @@ addAttributeToDomain domain@(DomainSet r (SetAttr sizeAttr) inner) = updater whe
         AttrName_minSize -> do
             let fails = fail $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
-                SizeAttr_Size s | val == s          -> return domain
-                SizeAttr_Size{}                     -> fails
-                SizeAttr_MinSize minS               -> return $ DomainSet r (SetAttr (SizeAttr_MinSize (mkMax minS val))) inner
-                SizeAttr_MaxSize maxS | val == maxS -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
-                SizeAttr_MaxSize maxS               -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize val maxS)) inner
+                SizeAttr_Size s | val == s    -> return domain
+                SizeAttr_Size{}               -> fails
+                SizeAttr_MinSize minS         -> return $ DomainSet r (SetAttr (SizeAttr_MinSize (mkMax minS val))) inner
+                SizeAttr_MaxSize maxS      | val == maxS -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
+                SizeAttr_MaxSize maxS         -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize val maxS)) inner
                 SizeAttr_MinMaxSize _ maxS | val == maxS -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
-                SizeAttr_MinMaxSize minS maxS       -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize (mkMax minS val) maxS)) inner
-                SizeAttr_None{}                     -> return $ DomainSet r (SetAttr (SizeAttr_MinSize val)) inner
+                SizeAttr_MinMaxSize minS maxS -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize (mkMax minS val) maxS)) inner
+                SizeAttr_None{}               -> return $ DomainSet r (SetAttr (SizeAttr_MinSize val)) inner
         AttrName_maxSize -> do
             let fails = fail $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
-                SizeAttr_Size s | val == s          -> return domain
-                SizeAttr_Size{}                     -> fails
-                SizeAttr_MinSize minS | val == minS -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
-                SizeAttr_MinSize minS               -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize minS val)) inner
-                SizeAttr_MaxSize maxS               -> return $ DomainSet r (SetAttr (SizeAttr_MaxSize (mkMin maxS val))) inner
+                SizeAttr_Size s | val == s    -> return domain
+                SizeAttr_Size{}               -> fails
+                SizeAttr_MinSize minS      | val == minS -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
+                SizeAttr_MinSize minS         -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize minS val)) inner
+                SizeAttr_MaxSize maxS         -> return $ DomainSet r (SetAttr (SizeAttr_MaxSize (mkMin maxS val))) inner
                 SizeAttr_MinMaxSize minS _ | val == minS -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
-                SizeAttr_MinMaxSize minS maxS       -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize minS (mkMin maxS val))) inner
-                SizeAttr_None{}                     -> return $ DomainSet r (SetAttr (SizeAttr_MaxSize val)) inner
+                SizeAttr_MinMaxSize minS maxS -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize minS (mkMin maxS val))) inner
+                SizeAttr_None{}               -> return $ DomainSet r (SetAttr (SizeAttr_MaxSize val)) inner
         _ ->
             fail $ vcat [ "Unsupported attribute" <+> pretty attr
                         , "For the domain:" <+> pretty domain
@@ -132,49 +132,49 @@ addAttributeToDomain domain@(DomainMSet r (MSetAttr sizeAttr occurAttr) inner) =
         AttrName_minSize -> do
             let fails = fail $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
-                SizeAttr_Size s | val == s          -> return domain
-                SizeAttr_Size{}                     -> fails
-                SizeAttr_MinSize minS               -> return $ DomainMSet r
-                                                       (MSetAttr (SizeAttr_MinSize (mkMax minS val))         occurAttr)
-                                                       inner
-                SizeAttr_MaxSize maxS | val == maxS -> return $ DomainMSet r
-                                                       (MSetAttr (SizeAttr_Size val)                         occurAttr)
-                                                       inner
-                SizeAttr_MaxSize maxS               -> return $ DomainMSet r
-                                                       (MSetAttr (SizeAttr_MinMaxSize val maxS)              occurAttr)
-                                                       inner
-                SizeAttr_MinMaxSize _ maxS | val == maxS -> return $ DomainMSet r
-                                                            (MSetAttr (SizeAttr_Size val)                    occurAttr)
+                SizeAttr_Size s | val == s    -> return domain
+                SizeAttr_Size{}               -> fails
+                SizeAttr_MinSize minS         -> return $ DomainMSet r
+                                                 (MSetAttr (SizeAttr_MinSize (mkMax minS val))         occurAttr)
+                                                 inner
+                SizeAttr_MaxSize maxS      | val == maxS -> return $ DomainMSet r
+                                                            (MSetAttr (SizeAttr_Size val)              occurAttr)
                                                             inner
-                SizeAttr_MinMaxSize minS maxS       -> return $ DomainMSet r
-                                                       (MSetAttr (SizeAttr_MinMaxSize (mkMax minS val) maxS) occurAttr)
-                                                       inner
-                SizeAttr_None{}                     -> return $ DomainMSet r
-                                                       (MSetAttr (SizeAttr_MinSize val)                      occurAttr)
-                                                       inner
+                SizeAttr_MaxSize maxS         -> return $ DomainMSet r
+                                                 (MSetAttr (SizeAttr_MinMaxSize val maxS)              occurAttr)
+                                                 inner
+                SizeAttr_MinMaxSize _ maxS | val == maxS -> return $ DomainMSet r
+                                                            (MSetAttr (SizeAttr_Size val)              occurAttr)
+                                                            inner
+                SizeAttr_MinMaxSize minS maxS -> return $ DomainMSet r
+                                                 (MSetAttr (SizeAttr_MinMaxSize (mkMax minS val) maxS) occurAttr)
+                                                 inner
+                SizeAttr_None{}               -> return $ DomainMSet r
+                                                 (MSetAttr (SizeAttr_MinSize val)                      occurAttr)
+                                                 inner
         AttrName_maxSize -> do
             let fails = fail $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
-                SizeAttr_Size s | val == s          -> return domain
-                SizeAttr_Size{}                     -> fails
-                SizeAttr_MinSize minS | val == minS -> return $ DomainMSet r
-                                                       (MSetAttr (SizeAttr_Size val)                         occurAttr)
-                                                       inner
-                SizeAttr_MinSize minS               -> return $ DomainMSet r
-                                                       (MSetAttr (SizeAttr_MinMaxSize minS val)              occurAttr)
-                                                       inner
-                SizeAttr_MaxSize maxS               -> return $ DomainMSet r
-                                                       (MSetAttr (SizeAttr_MaxSize (mkMin maxS val))         occurAttr)
-                                                       inner
-                SizeAttr_MinMaxSize minS _ | val == minS -> return $ DomainMSet r
-                                                            (MSetAttr (SizeAttr_Size val)                    occurAttr)
+                SizeAttr_Size s | val == s    -> return domain
+                SizeAttr_Size{}               -> fails
+                SizeAttr_MinSize minS      | val == minS -> return $ DomainMSet r
+                                                            (MSetAttr (SizeAttr_Size val)              occurAttr)
                                                             inner
-                SizeAttr_MinMaxSize minS maxS       -> return $ DomainMSet r
-                                                       (MSetAttr (SizeAttr_MinMaxSize minS (mkMin maxS val)) occurAttr)
-                                                       inner
-                SizeAttr_None{}                     -> return $ DomainMSet r
-                                                       (MSetAttr (SizeAttr_MaxSize val)                      occurAttr)
-                                                       inner
+                SizeAttr_MinSize minS         -> return $ DomainMSet r
+                                                 (MSetAttr (SizeAttr_MinMaxSize minS val)              occurAttr)
+                                                 inner
+                SizeAttr_MaxSize maxS         -> return $ DomainMSet r
+                                                 (MSetAttr (SizeAttr_MaxSize (mkMin maxS val))         occurAttr)
+                                                 inner
+                SizeAttr_MinMaxSize minS _ | val == minS -> return $ DomainMSet r
+                                                            (MSetAttr (SizeAttr_Size val)              occurAttr)
+                                                            inner
+                SizeAttr_MinMaxSize minS maxS -> return $ DomainMSet r
+                                                 (MSetAttr (SizeAttr_MinMaxSize minS (mkMin maxS val)) occurAttr)
+                                                 inner
+                SizeAttr_None{}               -> return $ DomainMSet r
+                                                 (MSetAttr (SizeAttr_MaxSize val)                      occurAttr)
+                                                 inner
         AttrName_minOccur ->
             case occurAttr of
                 OccurAttr_MinOccur minO         -> return $ DomainMSet r
@@ -435,9 +435,9 @@ addAttributeToDomain domain@(DomainPartition r partitionAttr inner) = updater wh
                 SizeAttr_MinSize minS         -> return $ DomainPartition r
                                                  partitionAttr { partsNum = SizeAttr_MinSize (mkMax minS val) }
                                                  inner
-                SizeAttr_MaxSize maxS | val == maxS -> return $ DomainPartition r
-                                                       partitionAttr { partsNum = SizeAttr_Size val }
-                                                       inner
+                SizeAttr_MaxSize maxS      | val == maxS -> return $ DomainPartition r
+                                                            partitionAttr { partsNum = SizeAttr_Size val }
+                                                            inner
                 SizeAttr_MaxSize maxS         -> return $ DomainPartition r
                                                  partitionAttr { partsNum = SizeAttr_MinMaxSize val maxS }
                                                  inner
@@ -455,9 +455,9 @@ addAttributeToDomain domain@(DomainPartition r partitionAttr inner) = updater wh
             case partsNum partitionAttr of
                 SizeAttr_Size s | val == s    -> return domain
                 SizeAttr_Size{}               -> fails
-                SizeAttr_MinSize minS | val == minS -> return $ DomainPartition r
-                                                       partitionAttr { partsNum = SizeAttr_Size val }
-                                                       inner
+                SizeAttr_MinSize minS      | val == minS -> return $ DomainPartition r
+                                                            partitionAttr { partsNum = SizeAttr_Size val }
+                                                            inner
                 SizeAttr_MinSize minS         -> return $ DomainPartition r
                                                  partitionAttr { partsNum = SizeAttr_MinMaxSize minS val }
                                                  inner

--- a/src/Conjure/Language/Domain/AddAttributes.hs
+++ b/src/Conjure/Language/Domain/AddAttributes.hs
@@ -93,19 +93,23 @@ addAttributeToDomain domain@(DomainSet r (SetAttr sizeAttr) inner) = updater whe
         AttrName_minSize -> do
             let fails = fail $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
-                SizeAttr_Size{}               -> fails
-                SizeAttr_MinSize minS         -> return $ DomainSet r (SetAttr (SizeAttr_MinSize (mkMax minS val))) inner
-                SizeAttr_MaxSize maxS         -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize val maxS)) inner
-                SizeAttr_MinMaxSize minS maxS -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize (mkMax minS val) maxS)) inner
-                SizeAttr_None{}               -> return $ DomainSet r (SetAttr (SizeAttr_MinSize val)) inner
+                SizeAttr_Size{}                     -> fails
+                SizeAttr_MinSize minS               -> return $ DomainSet r (SetAttr (SizeAttr_MinSize (mkMax minS val))) inner
+                SizeAttr_MaxSize maxS | val == maxS -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
+                SizeAttr_MaxSize maxS               -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize val maxS)) inner
+                SizeAttr_MinMaxSize _ maxS | val == maxS -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
+                SizeAttr_MinMaxSize minS maxS       -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize (mkMax minS val) maxS)) inner
+                SizeAttr_None{}                     -> return $ DomainSet r (SetAttr (SizeAttr_MinSize val)) inner
         AttrName_maxSize -> do
             let fails = fail $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
-                SizeAttr_Size{}               -> fails
-                SizeAttr_MinSize minS         -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize minS val)) inner
-                SizeAttr_MaxSize maxS         -> return $ DomainSet r (SetAttr (SizeAttr_MaxSize (mkMin maxS val))) inner
-                SizeAttr_MinMaxSize minS maxS -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize minS (mkMin maxS val))) inner
-                SizeAttr_None{}               -> return $ DomainSet r (SetAttr (SizeAttr_MaxSize val)) inner
+                SizeAttr_Size{}                     -> fails
+                SizeAttr_MinSize minS | val == minS -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
+                SizeAttr_MinSize minS               -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize minS val)) inner
+                SizeAttr_MaxSize maxS               -> return $ DomainSet r (SetAttr (SizeAttr_MaxSize (mkMin maxS val))) inner
+                SizeAttr_MinMaxSize minS _ | val == minS -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
+                SizeAttr_MinMaxSize minS maxS       -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize minS (mkMin maxS val))) inner
+                SizeAttr_None{}                     -> return $ DomainSet r (SetAttr (SizeAttr_MaxSize val)) inner
         _ ->
             fail $ vcat [ "Unsupported attribute" <+> pretty attr
                         , "For the domain:" <+> pretty domain

--- a/src/Conjure/Language/Domain/AddAttributes.hs
+++ b/src/Conjure/Language/Domain/AddAttributes.hs
@@ -88,11 +88,13 @@ addAttributeToDomain domain@(DomainSet r (SetAttr sizeAttr) inner) = updater whe
     updater attr (Just val) = case attr of
         AttrName_size ->
             case sizeAttr of
-                SizeAttr_Size{} -> fail $ "Cannot add a size attribute to this domain:" <++> pretty domain
-                _               -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
+                SizeAttr_Size s | val == s -> return domain
+                SizeAttr_Size{}            -> fail $ "Cannot add a size attribute to this domain:" <++> pretty domain
+                _                          -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
         AttrName_minSize -> do
             let fails = fail $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
+                SizeAttr_Size s | val == s          -> return domain
                 SizeAttr_Size{}                     -> fails
                 SizeAttr_MinSize minS               -> return $ DomainSet r (SetAttr (SizeAttr_MinSize (mkMax minS val))) inner
                 SizeAttr_MaxSize maxS | val == maxS -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
@@ -103,6 +105,7 @@ addAttributeToDomain domain@(DomainSet r (SetAttr sizeAttr) inner) = updater whe
         AttrName_maxSize -> do
             let fails = fail $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
+                SizeAttr_Size s | val == s          -> return domain
                 SizeAttr_Size{}                     -> fails
                 SizeAttr_MinSize minS | val == minS -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
                 SizeAttr_MinSize minS               -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize minS val)) inner

--- a/src/Conjure/Language/Domain/AddAttributes.hs
+++ b/src/Conjure/Language/Domain/AddAttributes.hs
@@ -117,8 +117,8 @@ addAttributeToDomain domain@(DomainSet r (SetAttr sizeAttr) inner) = updater whe
             fail $ vcat [ "Unsupported attribute" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
-    updater attr _ =
-            fail $ vcat [ "Unsupported attribute" <+> pretty attr
+    updater attr Nothing =
+            fail $ vcat [ "Missing attribute value for" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
 
@@ -207,8 +207,8 @@ addAttributeToDomain domain@(DomainMSet r (MSetAttr sizeAttr occurAttr) inner) =
             fail $ vcat [ "Unsupported attribute" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
-    updater attr _ =
-            fail $ vcat [ "Unsupported attribute" <+> pretty attr
+    updater attr Nothing =
+            fail $ vcat [ "Missing attribute value for" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
 

--- a/src/Conjure/Language/Domain/AddAttributes.hs
+++ b/src/Conjure/Language/Domain/AddAttributes.hs
@@ -126,40 +126,55 @@ addAttributeToDomain domain@(DomainMSet r (MSetAttr sizeAttr occurAttr) inner) =
     updater attr (Just val) = case attr of
         AttrName_size ->
             case sizeAttr of
-                SizeAttr_Size{} -> fail $ "Cannot add a size attribute to this domain:" <++> pretty domain
-                _               -> return $ DomainMSet r (MSetAttr (SizeAttr_Size val) occurAttr) inner
+                SizeAttr_Size s | val == s -> return domain
+                SizeAttr_Size{}            -> fail $ "Cannot add a size attribute to this domain:" <++> pretty domain
+                _                          -> return $ DomainMSet r (MSetAttr (SizeAttr_Size val) occurAttr) inner
         AttrName_minSize -> do
             let fails = fail $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
-                SizeAttr_Size{}               -> fails
-                SizeAttr_MinSize minS         -> return $ DomainMSet r
-                                                    (MSetAttr (SizeAttr_MinSize (mkMax minS val))         occurAttr)
-                                                    inner
-                SizeAttr_MaxSize maxS         -> return $ DomainMSet r
-                                                    (MSetAttr (SizeAttr_MinMaxSize val maxS)              occurAttr)
-                                                    inner
-                SizeAttr_MinMaxSize minS maxS -> return $ DomainMSet r
-                                                    (MSetAttr (SizeAttr_MinMaxSize (mkMax minS val) maxS) occurAttr)
-                                                    inner
-                SizeAttr_None{}               -> return $ DomainMSet r
-                                                    (MSetAttr (SizeAttr_MinSize val)                      occurAttr)
-                                                    inner
+                SizeAttr_Size s | val == s          -> return domain
+                SizeAttr_Size{}                     -> fails
+                SizeAttr_MinSize minS               -> return $ DomainMSet r
+                                                       (MSetAttr (SizeAttr_MinSize (mkMax minS val))         occurAttr)
+                                                       inner
+                SizeAttr_MaxSize maxS | val == maxS -> return $ DomainMSet r
+                                                       (MSetAttr (SizeAttr_Size val)                         occurAttr)
+                                                       inner
+                SizeAttr_MaxSize maxS               -> return $ DomainMSet r
+                                                       (MSetAttr (SizeAttr_MinMaxSize val maxS)              occurAttr)
+                                                       inner
+                SizeAttr_MinMaxSize _ maxS | val == maxS -> return $ DomainMSet r
+                                                            (MSetAttr (SizeAttr_Size val)                    occurAttr)
+                                                            inner
+                SizeAttr_MinMaxSize minS maxS       -> return $ DomainMSet r
+                                                       (MSetAttr (SizeAttr_MinMaxSize (mkMax minS val) maxS) occurAttr)
+                                                       inner
+                SizeAttr_None{}                     -> return $ DomainMSet r
+                                                       (MSetAttr (SizeAttr_MinSize val)                      occurAttr)
+                                                       inner
         AttrName_maxSize -> do
             let fails = fail $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
-                SizeAttr_Size{}               -> fails
-                SizeAttr_MinSize minS         -> return $ DomainMSet r
-                                                    (MSetAttr (SizeAttr_MinMaxSize minS val)              occurAttr)
-                                                    inner
-                SizeAttr_MaxSize maxS         -> return $ DomainMSet r
-                                                    (MSetAttr (SizeAttr_MaxSize (mkMin maxS val))         occurAttr)
-                                                    inner
-                SizeAttr_MinMaxSize minS maxS -> return $ DomainMSet r
-                                                    (MSetAttr (SizeAttr_MinMaxSize minS (mkMin maxS val)) occurAttr)
-                                                    inner
-                SizeAttr_None{}               -> return $ DomainMSet r
-                                                    (MSetAttr (SizeAttr_MaxSize val)                      occurAttr)
-                                                    inner
+                SizeAttr_Size s | val == s          -> return domain
+                SizeAttr_Size{}                     -> fails
+                SizeAttr_MinSize minS | val == minS -> return $ DomainMSet r
+                                                       (MSetAttr (SizeAttr_Size val)                         occurAttr)
+                                                       inner
+                SizeAttr_MinSize minS               -> return $ DomainMSet r
+                                                       (MSetAttr (SizeAttr_MinMaxSize minS val)              occurAttr)
+                                                       inner
+                SizeAttr_MaxSize maxS               -> return $ DomainMSet r
+                                                       (MSetAttr (SizeAttr_MaxSize (mkMin maxS val))         occurAttr)
+                                                       inner
+                SizeAttr_MinMaxSize minS _ | val == minS -> return $ DomainMSet r
+                                                            (MSetAttr (SizeAttr_Size val)                    occurAttr)
+                                                            inner
+                SizeAttr_MinMaxSize minS maxS       -> return $ DomainMSet r
+                                                       (MSetAttr (SizeAttr_MinMaxSize minS (mkMin maxS val)) occurAttr)
+                                                       inner
+                SizeAttr_None{}                     -> return $ DomainMSet r
+                                                       (MSetAttr (SizeAttr_MaxSize val)                      occurAttr)
+                                                       inner
         AttrName_minOccur -> do
             let fails = fail $ "Cannot add a minOccur attribute to this domain:" <++> pretty domain
             case occurAttr of

--- a/src/Conjure/Language/Domain/AddAttributes.hs
+++ b/src/Conjure/Language/Domain/AddAttributes.hs
@@ -175,28 +175,34 @@ addAttributeToDomain domain@(DomainMSet r (MSetAttr sizeAttr occurAttr) inner) =
                 SizeAttr_None{}                     -> return $ DomainMSet r
                                                        (MSetAttr (SizeAttr_MaxSize val)                      occurAttr)
                                                        inner
-        AttrName_minOccur -> do
-            let fails = fail $ "Cannot add a minOccur attribute to this domain:" <++> pretty domain
+        AttrName_minOccur ->
             case occurAttr of
-                OccurAttr_MinOccur{}    -> fails
-                OccurAttr_MinMaxOccur{} -> fails
-                OccurAttr_None          -> return $ DomainMSet r
-                                            (MSetAttr sizeAttr (OccurAttr_MinOccur val))
-                                            inner
-                OccurAttr_MaxOccur maxO -> return $ DomainMSet r
-                                            (MSetAttr sizeAttr (OccurAttr_MinMaxOccur val maxO))
-                                            inner
-        AttrName_maxOccur -> do
-            let fails = fail $ "Cannot add a maxOccur attribute to this domain:" <++> pretty domain
+                OccurAttr_MinOccur minO         -> return $ DomainMSet r
+                                                   (MSetAttr sizeAttr (OccurAttr_MinOccur (mkMax minO val)))
+                                                   inner
+                OccurAttr_MaxOccur maxO         -> return $ DomainMSet r
+                                                   (MSetAttr sizeAttr (OccurAttr_MinMaxOccur val maxO))
+                                                   inner
+                OccurAttr_MinMaxOccur minO maxO -> return $ DomainMSet r
+                                                   (MSetAttr sizeAttr (OccurAttrMinMaxOccur (mkMax minO val) maxO))
+                                                   inner
+                OccurAttr_None                  -> return $ DomainMSet r
+                                                   (MSetAttr sizeAttr (OccurAttr_MinOccur val))
+                                                   inner
+        AttrName_maxOccur ->
             case occurAttr of
-                OccurAttr_MaxOccur{}    -> fails
-                OccurAttr_MinMaxOccur{} -> fails
-                OccurAttr_None          -> return $ DomainMSet r
-                                            (MSetAttr sizeAttr (OccurAttr_MaxOccur val))
-                                            inner
-                OccurAttr_MinOccur minO -> return $ DomainMSet r
-                                            (MSetAttr sizeAttr (OccurAttr_MinMaxOccur minO val))
-                                            inner
+                OccurAttr_MinOccur minO         -> return $ DomainMSet r
+                                                   (MSetAttr sizeAttr (OccurAttr_MinMaxOccur minO val))
+                                                   inner
+                OccurAttr_MaxOccur maxO         -> return $ DomainMSet r
+                                                   (MSetAttr sizeAttr (OccurAttr_MaxOccur (mkMax maxO val)))
+                                                   inner
+                OccurAttr_MinMaxOccur minO maxO -> sreturn $ DomainMSet r
+                                                   (MSetAttr sizeAttr (OccurAttr_MinMaxOccur minO (mkMax maxO val)))
+                                                   inner
+                OccurAttr_None                  -> return $ DomainMSet r
+                                                   (MSetAttr sizeAttr (OccurAttr_MaxOccur val))
+                                                   inner
         _ ->
             fail $ vcat [ "Unsupported attribute" <+> pretty attr
                         , "For the domain:" <+> pretty domain

--- a/src/Conjure/Language/Domain/AddAttributes.hs
+++ b/src/Conjure/Language/Domain/AddAttributes.hs
@@ -184,7 +184,7 @@ addAttributeToDomain domain@(DomainMSet r (MSetAttr sizeAttr occurAttr) inner) =
                                                    (MSetAttr sizeAttr (OccurAttr_MinMaxOccur val maxO))
                                                    inner
                 OccurAttr_MinMaxOccur minO maxO -> return $ DomainMSet r
-                                                   (MSetAttr sizeAttr (OccurAttrMinMaxOccur (mkMax minO val) maxO))
+                                                   (MSetAttr sizeAttr (OccurAttr_MinMaxOccur (mkMax minO val) maxO))
                                                    inner
                 OccurAttr_None                  -> return $ DomainMSet r
                                                    (MSetAttr sizeAttr (OccurAttr_MinOccur val))
@@ -195,10 +195,10 @@ addAttributeToDomain domain@(DomainMSet r (MSetAttr sizeAttr occurAttr) inner) =
                                                    (MSetAttr sizeAttr (OccurAttr_MinMaxOccur minO val))
                                                    inner
                 OccurAttr_MaxOccur maxO         -> return $ DomainMSet r
-                                                   (MSetAttr sizeAttr (OccurAttr_MaxOccur (mkMax maxO val)))
+                                                   (MSetAttr sizeAttr (OccurAttr_MaxOccur (mkMin maxO val)))
                                                    inner
-                OccurAttr_MinMaxOccur minO maxO -> sreturn $ DomainMSet r
-                                                   (MSetAttr sizeAttr (OccurAttr_MinMaxOccur minO (mkMax maxO val)))
+                OccurAttr_MinMaxOccur minO maxO -> return $ DomainMSet r
+                                                   (MSetAttr sizeAttr (OccurAttr_MinMaxOccur minO (mkMin maxO val)))
                                                    inner
                 OccurAttr_None                  -> return $ DomainMSet r
                                                    (MSetAttr sizeAttr (OccurAttr_MaxOccur val))


### PR DESCRIPTION
Adding a size attribute to a `set` or `mset` domain will merge the values being added if an existing size attribute of the given type is present, using `max` for `minSize` and `min` for `maxSize`.

It only applies to size attributes on sets and multisets for now, in case a different implementation is preferred or if the change is not desirable. Extending it to other domains will be repetitive but not difficult.

An example of this change being applied follows, and does indeed fire with a `MainHelper.hs` modified for the contrived example. Calling `addAttributesToDomain` with `minSize 5` will now update the internal Essence spec to be `minSize max([3, 5])` and the output Essence' to be `minSize 5`. The previous behaviour was to fail.

```essence
find s : set (minSize 3) of int(1..10)

==> find s: set (minSize max([3, 5; int(1..2)])) of int(1..10)

==> find s_Occurrence: matrix indexed by [int(1..10)] of bool
    such that 5 <= sum([toInt(s_Occurrence[q1]) | q1 : int(1..10)]) 
```

- Merging two `max` expressions performs a set union on their elements,
- Merging a value with a `max` expression inserts it if it is not already present,
- Merging two values creates a `max` expression if they are not equal,
- Merging two equal values makes no change.

If the `maxSize` attribute is set, the `min` of the values is taken instead.