### PR TITLE
Comparator fix

### DIFF
--- a/src/Conjure/Language/Expression/Op/Leq.hs
+++ b/src/Conjure/Language/Expression/Op/Leq.hs
@@ -22,12 +22,7 @@ instance BinaryOperator (OpLeq x) where
     opLexeme _ = L_Leq
 
 instance (TypeOf x, Pretty x) => TypeOf (OpLeq x) where
-    typeOf p@(OpLeq a b) = sameToSameToBool p a b [] $ \case
-        TypeBool -> True
-        TypeInt{} | ?typeCheckerMode == RelaxedIntegerTags -> True
-        TypeInt TagInt -> True
-        TypeInt TagEnum{} -> True
-        _ -> False
+    typeOf p@(OpLeq a b) = sameToSameToBool p a b [] (const True) 
 
 instance SimplifyOp OpLeq x where
     simplifyOp _ = na "simplifyOp{OpLeq}"

--- a/src/Conjure/Language/Expression/Op/Lt.hs
+++ b/src/Conjure/Language/Expression/Op/Lt.hs
@@ -22,12 +22,7 @@ instance BinaryOperator (OpLt x) where
     opLexeme _ = L_Lt
 
 instance (TypeOf x, Pretty x) => TypeOf (OpLt x) where
-    typeOf p@(OpLt a b) = sameToSameToBool p a b [] $ \case
-        TypeBool -> True
-        TypeInt{} | ?typeCheckerMode == RelaxedIntegerTags -> True
-        TypeInt TagInt -> True
-        TypeInt TagEnum{} -> True
-        _ -> False
+    typeOf p@(OpLt a b) = sameToSameToBool p a b [] (const True) 
 
 instance SimplifyOp OpLt x where
     simplifyOp _ = na "simplifyOp{OpLt}"

--- a/src/Conjure/Representations.hs
+++ b/src/Conjure/Representations.hs
@@ -166,10 +166,13 @@ symmetryOrdering inp =
                 case mDom of
                     DomainMatrix _ domainInner -> symmetryOrderingDispatch downX1 inp domainInner
                     _ -> bug ("symmetryOrdering, not DomainMatrix:" <++> pretty (show op))
+            MkOpSum (OpSum m) -> return $ fromList [Op (MkOpSum (OpSum m))]    
             _ -> bug ("symmetryOrdering, unhandled Op:" <++> pretty (show op))
-        -- Comprehension body stmts -> do
-        --     xs <- downX1 body
-        --     return [Comprehension x stmts | x <- xs]
+        Comprehension body stmts -> do
+            xs <- symmetryOrdering body
+            let toflat = Comprehension xs stmts 
+            return [essence| flatten(&toflat) |]            
         -- x@WithLocals{} -> bug ("downX1:" <++> pretty (show x))
-        _ -> bug ("symmetryOrdering:" <++> pretty (show inp))
+        _ -> bug ("symmetryOrdering: this probably happened because we are missing a case: please report it"
+                  <++> pretty (show inp))
 

--- a/src/Conjure/Representations/Function/Function1DPartial.hs
+++ b/src/Conjure/Representations/Function/Function1DPartial.hs
@@ -211,12 +211,5 @@ function1DPartial = Representation chck downD structuralCons downC up symmetryOr
             Just [_, (_, DomainMatrix innerDomainFr innerDomainTo)] <- downD ("SO", domain)
             (iPat, i) <- quantifiedVar
             soValues <- innerSO downX1 [essence| &values[&i] |] innerDomainTo
-            return
-                [essence|
-                    [ ( -toInt(&flags[&i])
-                      , &soValues
-                      )
-                    | &iPat : &innerDomainFr
-                    ]
-                |]
+            return [essence| flatten([ flatten( [[-toInt(&flags[&i])], &soValues]) | &iPat : &innerDomainFr]) |]
 

--- a/src/Conjure/Representations/Function/FunctionNDPartial.hs
+++ b/src/Conjure/Representations/Function/FunctionNDPartial.hs
@@ -296,11 +296,7 @@ functionNDPartial = Representation chck downD structuralCons downC up symmetryOr
 
             soValues <- innerSO downX1 valuesIndexed innerDomainTo
 
-            return $ 
-                Comprehension
-                    [essence| ( -&flagsIndexed
-                              , &soValues
-                              )
-                            |]
-                    [Generator (GenDomainNoRepr iPat (forgetRepr innerDomainFr))]
+            let toflat = Comprehension [essence| flatten([ -&flagsIndexed, &soValues]) |]
+                                  [Generator (GenDomainNoRepr iPat (forgetRepr innerDomainFr))]
+            return [essence| flatten(&toflat) |]
 

--- a/src/Conjure/Representations/MSet/ExplicitWithFlags.hs
+++ b/src/Conjure/Representations/MSet/ExplicitWithFlags.hs
@@ -209,12 +209,5 @@ msetExplicitWithFlags = Representation chck downD structuralCons downC up symmet
             Just [_, (_, DomainMatrix index inner)] <- downD ("SO", domain)
             (iPat, i) <- quantifiedVar
             soValues <- innerSO downX1 [essence| &values[&i] |] inner
-            return
-                [essence|
-                    [ ( -&flags[&i]
-                      , &soValues
-                      )
-                    | &iPat : &index
-                    ]
-                |]
+            return [essence| flatten([ flatten([ [-&flags[&i]], &soValues]) | &iPat : &index ]) |]
 

--- a/src/Conjure/Representations/MSet/ExplicitWithRepetition.hs
+++ b/src/Conjure/Representations/MSet/ExplicitWithRepetition.hs
@@ -226,12 +226,5 @@ msetExplicitWithRepetition = Representation chck downD structuralCons downC up s
             Just [_, (_, DomainMatrix index inner)] <- downD ("SO", domain)
             (iPat, i) <- quantifiedVar
             soValues <- innerSO downX1 [essence| &values[&i] |] inner
-            return
-                [essence|
-                    ( &marker
-                    , [ &soValues
-                      | &iPat : &index
-                      ]
-                    )
-                |]
+            return [essence| flatten( [[&marker], flatten([ &soValues | &iPat : &index])]) |]
 

--- a/src/Conjure/Representations/Matrix.hs
+++ b/src/Conjure/Representations/Matrix.hs
@@ -202,5 +202,5 @@ matrix downD1 downC1 up1 = Representation chck matrixDownD structuralCons matrix
                     (iPat, i) <- quantifiedVarOverDomain indexDom
                     let mi = [essence| &inp[&i] |]
                     res <- innerSO downX1 mi innerDom
-                    return [essence| [ &res | &iPat : &indexDom ] |]
+                    return [essence| flatten([ &res | &iPat : &indexDom ]) |]
                 _ -> bug $ "symmetryOrdering matrix" <+> pretty inp <+> pretty domain

--- a/src/Conjure/Representations/Partition/Occurrence.hs
+++ b/src/Conjure/Representations/Partition/Occurrence.hs
@@ -321,5 +321,6 @@ partitionOccurrence = Representation chck downD structuralCons downC up symmetry
             Just xsDoms' <- downD ("SO", domain)
             let xsDoms = map snd xsDoms'
             soValues <- sequence [ innerSO downX1 x xDom | (x, xDom) <- zip xs xsDoms ]
-            return $ AbstractLiteral $ AbsLitTuple soValues 
+            let toflat = fromList soValues
+            return [essence| flatten(&toflat) |]
 

--- a/src/Conjure/Representations/Primitive.hs
+++ b/src/Conjure/Representations/Primitive.hs
@@ -30,7 +30,7 @@ primitive = Representation
             Just c  -> return (name, c)
     , rSymmetryOrdering = \ _innerSO _downX1 inp domain -> return $
         case domain of
-            DomainBool -> [essence| -toInt(&inp) |]
-            _          -> [essence| &inp |]
+            DomainBool -> [essence| [-toInt(&inp)] |]
+            _          -> [essence| [&inp] |]
     }
 

--- a/src/Conjure/Representations/Record.hs
+++ b/src/Conjure/Representations/Record.hs
@@ -82,6 +82,7 @@ record = Representation chck downD structuralCons downC up symmetryOrdering
             xs <- downX1 inp
             Just xsDoms' <- downD ("SO", domain)
             let xsDoms = map snd xsDoms'
-            soValues <- sequence [ innerSO downX1 x xDom | (x, xDom) <- zip xs xsDoms ]
-            return $ AbstractLiteral $ AbsLitTuple soValues
+            soVals <- sequence [ innerSO downX1 x xDom | (x, xDom) <- zip xs xsDoms ]
+            let toflat = fromList soVals
+            return [essence| flatten(&toflat) |] 
 

--- a/src/Conjure/Representations/Sequence/ExplicitBounded.hs
+++ b/src/Conjure/Representations/Sequence/ExplicitBounded.hs
@@ -286,11 +286,4 @@ sequenceExplicitBounded = Representation chck downD structuralCons downC up symm
             Just [_, (_, DomainMatrix index inner)] <- downD ("SO", domain)
             (iPat, i) <- quantifiedVar
             soValues <- innerSO downX1 [essence| &values[&i] |] inner
-            return
-                [essence|
-                    ( &marker
-                    , [ &soValues
-                      | &iPat : &index
-                      ]
-                    )
-                |]
+            return [essence| flatten( [&marker, flatten([ &soValues | &iPat : &index])]) |]

--- a/src/Conjure/Representations/Set/ExplicitVarSizeWithFlags.hs
+++ b/src/Conjure/Representations/Set/ExplicitVarSizeWithFlags.hs
@@ -193,6 +193,6 @@ setExplicitVarSizeWithFlags = Representation chck downD structuralCons downC up 
             soValues <- innerSO downX1 [essence| &values[&i] |] inner
             return
                 [essence|
-                    [ (&flags[&i], &soValues) | &iPat : &index]
+                    flatten([ flatten([[-toInt(&flags[&i])], &soValues]) | &iPat : &index])
                 |]
 

--- a/src/Conjure/Representations/Set/ExplicitVarSizeWithMarker.hs
+++ b/src/Conjure/Representations/Set/ExplicitVarSizeWithMarker.hs
@@ -164,12 +164,5 @@ setExplicitVarSizeWithMarker = Representation chck downD structuralCons downC up
             Just [_, (_, DomainMatrix index inner)] <- downD ("SO", domain)
             (iPat, i) <- quantifiedVar
             soValues <- innerSO downX1 [essence| &values[&i] |] inner
-            return
-                [essence|
-                    ( &marker
-                    ,[ &soValues
-                     | &iPat : &index
-                     ]
-                    )
-                |]
+            return [essence| flatten([[&marker],flatten([ &soValues | &iPat : &index])]) |]
 

--- a/src/Conjure/Representations/Tuple.hs
+++ b/src/Conjure/Representations/Tuple.hs
@@ -82,6 +82,7 @@ tuple = Representation chck downD structuralCons downC up symmetryOrdering
             xs <- downX1 inp
             Just xsDoms' <- downD ("SO", domain)
             let xsDoms = map snd xsDoms'
-            soValues <- sequence [ innerSO downX1 x xDom | (x, xDom) <- zip xs xsDoms ]
-            return $ AbstractLiteral $ AbsLitTuple soValues
+            soVals <- sequence [ innerSO downX1 x xDom | (x, xDom) <- zip xs xsDoms ]
+            let toflat = fromList soVals
+            return [essence| flatten(&toflat) |]
 

--- a/src/Conjure/Representations/Variant.hs
+++ b/src/Conjure/Representations/Variant.hs
@@ -121,5 +121,7 @@ variant = Representation chck downD structuralCons downC up symmetryOrdering
             Just xsDoms' <- downD ("SO", domain)
             let xsDoms = map snd xsDoms'
             soValues <- sequence [ innerSO downX1 x xDom | (x, xDom) <- zip xs xsDoms ]
-            return (fromList soValues)
+            let toflat = (fromList soValues)
+            return [essence| flatten(&toflat) |]
+
 

--- a/testlog.txt
+++ b/testlog.txt
@@ -1,0 +1,534 @@
+Using Savile Row options: -run-solver -all-solutions -preprocess None -S0 -O0
+conjure
+  exhaustive
+    basic.partition_03:                                                                               FAIL
+      Exception: This should never happen, sorry!
+      
+      However, it did happen, so it must be a bug. Please report it to us!
+      
+      Conjure is actively maintained, we will get back to you as soon as possible.
+      You can help us by providing a minimal failing example.
+      
+      Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+      
+      Issue tracker: http://github.com/conjure-cp/conjure/issues
+      
+      
+      
+      Not refined: x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Values[q4] .<
+                   x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Values[q4 + 1]
+      Not refined: x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Values
+      Domain     : matrix indexed by [int(1..6)] of set {Occurrence} (size 3) of int(1..6)
+          Context #1: x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Values[q4]
+          Context #2: x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Values[q4] .<
+                      x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Values[q4 + 1]
+          Context #3: q4 + 1 <= x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Marker ->
+                      x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Values[q4] .<
+                      x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Values[q4 + 1]
+          Context #4: [q4 + 1 <= x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Marker ->
+                       x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Values[q4] .<
+                       x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Values[q4 + 1]
+                           | q4 : int(1..5)]
+          Context #5: and([q4 + 1 <= x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Marker ->
+                           x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Values[q4] .<
+                           x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Values[q4 + 1]
+                               | q4 : int(1..5)])
+          Context #1: x_PartitionAsSet_ExplicitVarSizeWithMarkerR2_Values[q4 + 1]
+      
+      CallStack (from HasCallStack):
+        error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+        bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+    basic.enum_liberated:                                                                             FAIL
+      Exception: ExitFailure 2
+    basic.relation06_set_bounded_direct:                                                              FAIL
+      Exception: This should never happen, sorry!
+      
+      However, it did happen, so it must be a bug. Please report it to us!
+      
+      Conjure is actively maintained, we will get back to you as soon as possible.
+      You can help us by providing a minimal failing example.
+      
+      Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+      
+      Issue tracker: http://github.com/conjure-cp/conjure/issues
+      
+      
+      
+      Not refined: x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Values[q1] .<
+                   x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+      Not refined: x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Values
+      Domain     : matrix indexed by [int(1..3)] of (int(1..2), set {Occurrence} (size 2) of int(1..3))
+          Context #1: x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Values[q1]
+          Context #2: x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Values[q1] .<
+                      x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+          Context #3: q1 + 1 <= x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Marker ->
+                      x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Values[q1] .<
+                      x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+          Context #4: [q1 + 1 <= x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Marker ->
+                       x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Values[q1] .<
+                       x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+                           | q1 : int(1..2)]
+          Context #5: and([q1 + 1 <= x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Marker ->
+                           x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Values[q1] .<
+                           x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+                               | q1 : int(1..2)])
+          Context #1: x_RelationAsSetR2_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+      
+      CallStack (from HasCallStack):
+        error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+        bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+    basic.partition_02:                                                                               FAIL
+      Exception: This should never happen, sorry!
+      
+      However, it did happen, so it must be a bug. Please report it to us!
+      
+      Conjure is actively maintained, we will get back to you as soon as possible.
+      You can help us by providing a minimal failing example.
+      
+      Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+      
+      Issue tracker: http://github.com/conjure-cp/conjure/issues
+      
+      
+      
+      Not refined: x_PartitionAsSet_ExplicitR2[1] .< x_PartitionAsSet_ExplicitR2[2]
+      Not refined: x_PartitionAsSet_ExplicitR2
+      Domain     : matrix indexed by [int(1..2)] of set {Occurrence} (maxSize 6) of int(1..6)
+          Context #1: x_PartitionAsSet_ExplicitR2[1]
+          Context #2: x_PartitionAsSet_ExplicitR2[1] .< x_PartitionAsSet_ExplicitR2[2]
+          Context #1: x_PartitionAsSet_ExplicitR2[2]
+      
+      CallStack (from HasCallStack):
+        error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+        bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+    basic.setOfSet03:                                                                                 FAIL
+      Exception: This should never happen, sorry!
+      
+      However, it did happen, so it must be a bug. Please report it to us!
+      
+      Conjure is actively maintained, we will get back to you as soon as possible.
+      You can help us by providing a minimal failing example.
+      
+      Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+      
+      Issue tracker: http://github.com/conjure-cp/conjure/issues
+      
+      
+      
+      Not refined: x_ExplicitR2[1] .< x_ExplicitR2[2]
+      Not refined: x_ExplicitR2
+      Domain     : matrix indexed by [int(1..2)] of set {Occurrence} (size 3) of int(1..4)
+          Context #1: x_ExplicitR2[1]
+          Context #2: x_ExplicitR2[1] .< x_ExplicitR2[2]
+          Context #1: x_ExplicitR2[2]
+      
+      CallStack (from HasCallStack):
+        error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+        bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+    basic.relation05_set_fixed_direct:                                                                FAIL
+      Exception: This should never happen, sorry!
+      
+      However, it did happen, so it must be a bug. Please report it to us!
+      
+      Conjure is actively maintained, we will get back to you as soon as possible.
+      You can help us by providing a minimal failing example.
+      
+      Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+      
+      Issue tracker: http://github.com/conjure-cp/conjure/issues
+      
+      
+      
+      Not refined: x_RelationAsSetR2_ExplicitR2[q1] .< x_RelationAsSetR2_ExplicitR2[q1 + 1]
+      Not refined: x_RelationAsSetR2_ExplicitR2
+      Domain     : matrix indexed by [int(1..4)] of (int(1..2), set {Occurrence} (size 2) of int(1..3))
+          Context #1: x_RelationAsSetR2_ExplicitR2[q1]
+          Context #2: x_RelationAsSetR2_ExplicitR2[q1] .< x_RelationAsSetR2_ExplicitR2[q1 + 1]
+          Context #3: [x_RelationAsSetR2_ExplicitR2[q1] .< x_RelationAsSetR2_ExplicitR2[q1 + 1] | q1 : int(1..3)]
+          Context #4: and([x_RelationAsSetR2_ExplicitR2[q1] .< x_RelationAsSetR2_ExplicitR2[q1 + 1] | q1 : int(1..3)])
+          Context #1: x_RelationAsSetR2_ExplicitR2[q1 + 1]
+      
+      CallStack (from HasCallStack):
+        error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+        bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+    basic.relation05_set_fixed_setty:                                                                 FAIL
+      Exception: This should never happen, sorry!
+      
+      However, it did happen, so it must be a bug. Please report it to us!
+      
+      Conjure is actively maintained, we will get back to you as soon as possible.
+      You can help us by providing a minimal failing example.
+      
+      Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+      
+      Issue tracker: http://github.com/conjure-cp/conjure/issues
+      
+      
+      
+      Not refined: x_ExplicitR2[q1] .< x_ExplicitR2[q1 + 1]
+      Not refined: x_ExplicitR2
+      Domain     : matrix indexed by [int(1..4)] of (int(1..2), set {Occurrence} (size 2) of int(1..3))
+          Context #1: x_ExplicitR2[q1]
+          Context #2: x_ExplicitR2[q1] .< x_ExplicitR2[q1 + 1]
+          Context #3: [x_ExplicitR2[q1] .< x_ExplicitR2[q1 + 1] | q1 : int(1..3)]
+          Context #4: and([x_ExplicitR2[q1] .< x_ExplicitR2[q1 + 1] | q1 : int(1..3)])
+          Context #1: x_ExplicitR2[q1 + 1]
+      
+      CallStack (from HasCallStack):
+        error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+        bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+    basic.partition_01:                                                                               FAIL
+      Exception: This should never happen, sorry!
+      
+      However, it did happen, so it must be a bug. Please report it to us!
+      
+      Conjure is actively maintained, we will get back to you as soon as possible.
+      You can help us by providing a minimal failing example.
+      
+      Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+      
+      Issue tracker: http://github.com/conjure-cp/conjure/issues
+      
+      
+      
+      Not refined: x_PartitionAsSet_ExplicitR2[1] .< x_PartitionAsSet_ExplicitR2[2]
+      Not refined: x_PartitionAsSet_ExplicitR2
+      Domain     : matrix indexed by [int(1..2)] of set {Occurrence} (size 3) of int(3..8)
+          Context #1: x_PartitionAsSet_ExplicitR2[1]
+          Context #2: x_PartitionAsSet_ExplicitR2[1] .< x_PartitionAsSet_ExplicitR2[2]
+          Context #1: x_PartitionAsSet_ExplicitR2[2]
+      
+      CallStack (from HasCallStack):
+        error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+        bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+    basic.relation06_set_bounded_setty:                                                               FAIL
+      Exception: This should never happen, sorry!
+      
+      However, it did happen, so it must be a bug. Please report it to us!
+      
+      Conjure is actively maintained, we will get back to you as soon as possible.
+      You can help us by providing a minimal failing example.
+      
+      Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+      
+      Issue tracker: http://github.com/conjure-cp/conjure/issues
+      
+      
+      
+      Not refined: x_ExplicitVarSizeWithMarkerR2_Values[q1] .< x_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+      Not refined: x_ExplicitVarSizeWithMarkerR2_Values
+      Domain     : matrix indexed by [int(1..3)] of (int(1..2), set {Occurrence} (size 2) of int(1..3))
+          Context #1: x_ExplicitVarSizeWithMarkerR2_Values[q1]
+          Context #2: x_ExplicitVarSizeWithMarkerR2_Values[q1] .< x_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+          Context #3: q1 + 1 <= x_ExplicitVarSizeWithMarkerR2_Marker ->
+                      x_ExplicitVarSizeWithMarkerR2_Values[q1] .< x_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+          Context #4: [q1 + 1 <= x_ExplicitVarSizeWithMarkerR2_Marker ->
+                       x_ExplicitVarSizeWithMarkerR2_Values[q1] .< x_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+                           | q1 : int(1..2)]
+          Context #5: and([q1 + 1 <= x_ExplicitVarSizeWithMarkerR2_Marker ->
+                           x_ExplicitVarSizeWithMarkerR2_Values[q1] .< x_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+                               | q1 : int(1..2)])
+          Context #1: x_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+      
+      CallStack (from HasCallStack):
+        error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+        bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+    issues.182:                                                                                       FAIL
+      Exception: This should never happen, sorry!
+      
+      However, it did happen, so it must be a bug. Please report it to us!
+      
+      Conjure is actively maintained, we will get back to you as soon as possible.
+      You can help us by providing a minimal failing example.
+      
+      Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+      
+      Issue tracker: http://github.com/conjure-cp/conjure/issues
+      
+      
+      
+      Not refined: p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values[q4] .<
+                   p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values[q4 + 1]
+      Not refined: p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values
+      Domain     : matrix indexed by [int(1..let1)] of set {ExplicitVarSizeWithMarker} (maxSize let2) of
+                                                           matrix indexed by [int(1..2)] of int(1..2)
+          Context #1: p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values[q4]
+          Context #2: p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values[q4] .<
+                      p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values[q4 + 1]
+          Context #3: q4 + 1 <= p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Marker ->
+                      p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values[q4] .<
+                      p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values[q4 + 1]
+          Context #4: [q4 + 1 <= p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Marker ->
+                       p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values[q4] .<
+                       p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values[q4 + 1]
+                           | q4 : int(1..3)]
+          Context #5: and([q4 + 1 <= p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Marker ->
+                           p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values[q4] .<
+                           p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values[q4 + 1]
+                               | q4 : int(1..3)])
+          Context #1: p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values[q4 + 1]
+      
+      CallStack (from HasCallStack):
+        error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+        bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+    autogen.gen34_2:                                                                                  FAIL
+      Exception: ExitFailure 2
+    autogen.gen34_1:                                                                                  FAIL
+      Exception: ExitFailure 2
+    autogen.gen35:                                                                                    FAIL
+      Exception: This should never happen, sorry!
+      
+      However, it did happen, so it must be a bug. Please report it to us!
+      
+      Conjure is actively maintained, we will get back to you as soon as possible.
+      You can help us by providing a minimal failing example.
+      
+      Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+      
+      Issue tracker: http://github.com/conjure-cp/conjure/issues
+      
+      
+      
+      Not refined: var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values[q1] .<
+                   var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values[q1 + 1]
+      Not refined: var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values
+      Domain     : matrix indexed by [int(1..3)] of (mset {ExplicitWithFlags} (minSize 3, minOccur 0, maxOccur 0) of bool,
+                                                     relation {RelationAsMatrix} (minSize 4) of (bool * bool))
+          Context #1: var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values[q1]
+          Context #2: var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values[q1] .<
+                      var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values[q1 + 1]
+          Context #3: q1 + 1 <= var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Marker ->
+                      var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values[q1] .<
+                      var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values[q1 + 1]
+          Context #4: [q1 + 1 <= var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Marker ->
+                       var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values[q1] .<
+                       var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values[q1 + 1]
+                           | q1 : int(1..2)]
+          Context #5: and([q1 + 1 <= var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Marker ->
+                           var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values[q1] .<
+                           var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values[q1 + 1]
+                               | q1 : int(1..2)])
+          Context #1: var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values[q1 + 1]
+      
+      CallStack (from HasCallStack):
+        error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+        bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+    autogen.gen37:                                                                                    FAIL
+      Exception: This should never happen, sorry!
+      
+      However, it did happen, so it must be a bug. Please report it to us!
+      
+      Conjure is actively maintained, we will get back to you as soon as possible.
+      You can help us by providing a minimal failing example.
+      
+      Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+      
+      Issue tracker: http://github.com/conjure-cp/conjure/issues
+      
+      
+      
+      Not refined: var1_RelationAsSetR5R8_ExplicitR5R8[1] .< var1_RelationAsSetR5R8_ExplicitR5R8[2]
+      Not refined: var1_RelationAsSetR5R8_ExplicitR5R8
+      Domain     : matrix indexed by [int(1..2)] of (set {ExplicitVarSizeWithMarker} of bool,
+                                                     mset {ExplicitWithFlags} (size 0, minOccur 1) of bool)
+          Context #1: var1_RelationAsSetR5R8_ExplicitR5R8[1]
+          Context #2: var1_RelationAsSetR5R8_ExplicitR5R8[1] .< var1_RelationAsSetR5R8_ExplicitR5R8[2]
+          Context #1: var1_RelationAsSetR5R8_ExplicitR5R8[2]
+      
+      CallStack (from HasCallStack):
+        error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+        bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+  custom
+    basic.sat-branching-on:                                                                           FAIL (0.71s)
+      Running
+      Checking stderr
+        src/test/Conjure/Custom.hs:86:
+        unexpected stderr:
+            Error: Cannot find executable glucose (for solver glucose)
+            grep: conjure-output/*.solution: No such file or directory
+        was expecting:    
+    issues.408:                                                                                       FAIL (9.57s)
+      Running
+      Checking stderr
+        src/test/Conjure/Custom.hs:86:
+        unexpected stderr:
+            conjure: This should never happen, sorry!
+            
+            However, it did happen, so it must be a bug. Please report it to us!
+            
+            Conjure is actively maintained, we will get back to you as soon as possible.
+            You can help us by providing a minimal failing example.
+            
+            Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+            
+            Issue tracker: http://github.com/conjure-cp/conjure/issues
+            
+            
+            
+            Not refined: conjure_aux1_ExplicitVarSizeWithMarkerR2_Values[q8] .<
+                         conjure_aux1_ExplicitVarSizeWithMarkerR2_Values[q8 + 1]
+            Not refined: conjure_aux1_ExplicitVarSizeWithMarkerR2_Values
+            Domain     : matrix indexed by [int(1..factorial(5) /
+                                                   (factorial(4) * factorial(5 - 4)))] of set {Occurrence} (size 4) of int(1..5)
+                Context #1: conjure_aux1_ExplicitVarSizeWithMarkerR2_Values[q8]
+                Context #2: conjure_aux1_ExplicitVarSizeWithMarkerR2_Values[q8] .<
+                            conjure_aux1_ExplicitVarSizeWithMarkerR2_Values[q8 + 1]
+                Context #3: q8 + 1 <= conjure_aux1_ExplicitVarSizeWithMarkerR2_Marker ->
+                            conjure_aux1_ExplicitVarSizeWithMarkerR2_Values[q8] .<
+                            conjure_aux1_ExplicitVarSizeWithMarkerR2_Values[q8 + 1]
+                Context #4: [q8 + 1 <= conjure_aux1_ExplicitVarSizeWithMarkerR2_Marker ->
+                             conjure_aux1_ExplicitVarSizeWithMarkerR2_Values[q8] .<
+                             conjure_aux1_ExplicitVarSizeWithMarkerR2_Values[q8 + 1]
+                                 | q8 : int(1..4)]
+                Context #5: and([q8 + 1 <= conjure_aux1_ExplicitVarSizeWithMarkerR2_Marker ->
+                                 conjure_aux1_ExplicitVarSizeWithMarkerR2_Values[q8] .<
+                                 conjure_aux1_ExplicitVarSizeWithMarkerR2_Values[q8 + 1]
+                                     | q8 : int(1..4)])
+                Context #1: conjure_aux1_ExplicitVarSizeWithMarkerR2_Values[q8 + 1]
+            Not refined: S_ExplicitVarSizeWithMarkerR2_Values[q1] .< S_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+            Not refined: S_ExplicitVarSizeWithMarkerR2_Values
+            Domain     : matrix indexed by [int(1..5)] of set {Occurrence} (size 4) of int(1..5)
+                Context #1: S_ExplicitVarSizeWithMarkerR2_Values[q1]
+                Context #2: S_ExplicitVarSizeWithMarkerR2_Values[q1] .< S_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+                Context #3: q1 + 1 <= S_ExplicitVarSizeWithMarkerR2_Marker ->
+                            S_ExplicitVarSizeWithMarkerR2_Values[q1] .< S_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+                Context #4: [q1 + 1 <= S_ExplicitVarSizeWithMarkerR2_Marker ->
+                             S_ExplicitVarSizeWithMarkerR2_Values[q1] .< S_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+                                 | q1 : int(1..4)]
+                Context #5: and([q1 + 1 <= S_ExplicitVarSizeWithMarkerR2_Marker ->
+                                 S_ExplicitVarSizeWithMarkerR2_Values[q1] .< S_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+                                     | q1 : int(1..4)])
+                Context #1: S_ExplicitVarSizeWithMarkerR2_Values[q1 + 1]
+            
+            CallStack (from HasCallStack):
+              error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+              bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+            cat: 408.solution: No such file or directory
+            conjure: This should never happen, sorry!
+            
+            However, it did happen, so it must be a bug. Please report it to us!
+            
+            Conjure is actively maintained, we will get back to you as soon as possible.
+            You can help us by providing a minimal failing example.
+            
+            Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+            
+            Issue tracker: http://github.com/conjure-cp/conjure/issues
+            
+            
+            
+            Not refined: conjure_aux1_ExplicitVarSizeWithFlagsR2_Values[q10] .<
+                         conjure_aux1_ExplicitVarSizeWithFlagsR2_Values[q10 + 1]
+            Not refined: conjure_aux1_ExplicitVarSizeWithFlagsR2_Values
+            Domain     : matrix indexed by [int(1..factorial(5) /
+                                                   (factorial(4) * factorial(5 - 4)))] of set {Occurrence} (size 4) of int(1..5)
+                Context #1: conjure_aux1_ExplicitVarSizeWithFlagsR2_Values[q10]
+                Context #2: conjure_aux1_ExplicitVarSizeWithFlagsR2_Values[q10] .<
+                            conjure_aux1_ExplicitVarSizeWithFlagsR2_Values[q10 + 1]
+                Context #3: conjure_aux1_ExplicitVarSizeWithFlagsR2_Flags[q10 + 1] ->
+                            conjure_aux1_ExplicitVarSizeWithFlagsR2_Values[q10] .<
+                            conjure_aux1_ExplicitVarSizeWithFlagsR2_Values[q10 + 1]
+                Context #4: [conjure_aux1_ExplicitVarSizeWithFlagsR2_Flags[q10 + 1] ->
+                             conjure_aux1_ExplicitVarSizeWithFlagsR2_Values[q10] .<
+                             conjure_aux1_ExplicitVarSizeWithFlagsR2_Values[q10 + 1]
+                                 | q10 : int(1..4)]
+                Context #5: and([conjure_aux1_ExplicitVarSizeWithFlagsR2_Flags[q10 + 1] ->
+                                 conjure_aux1_ExplicitVarSizeWithFlagsR2_Values[q10] .<
+                                 conjure_aux1_ExplicitVarSizeWithFlagsR2_Values[q10 + 1]
+                                     | q10 : int(1..4)])
+                Context #1: conjure_aux1_ExplicitVarSizeWithFlagsR2_Values[q10 + 1]
+            Not refined: S_ExplicitVarSizeWithFlagsR2_Values[q1] .< S_ExplicitVarSizeWithFlagsR2_Values[q1 + 1]
+            Not refined: S_ExplicitVarSizeWithFlagsR2_Values
+            Domain     : matrix indexed by [int(1..5)] of set {Occurrence} (size 4) of int(1..5)
+                Context #1: S_ExplicitVarSizeWithFlagsR2_Values[q1]
+                Context #2: S_ExplicitVarSizeWithFlagsR2_Values[q1] .< S_ExplicitVarSizeWithFlagsR2_Values[q1 + 1]
+                Context #3: S_ExplicitVarSizeWithFlagsR2_Flags[q1 + 1] ->
+                            S_ExplicitVarSizeWithFlagsR2_Values[q1] .< S_ExplicitVarSizeWithFlagsR2_Values[q1 + 1]
+                Context #4: [S_ExplicitVarSizeWithFlagsR2_Flags[q1 + 1] ->
+                             S_ExplicitVarSizeWithFlagsR2_Values[q1] .< S_ExplicitVarSizeWithFlagsR2_Values[q1 + 1]
+                                 | q1 : int(1..4)]
+                Context #5: and([S_ExplicitVarSizeWithFlagsR2_Flags[q1 + 1] ->
+                                 S_ExplicitVarSizeWithFlagsR2_Values[q1] .< S_ExplicitVarSizeWithFlagsR2_Values[q1 + 1]
+                                     | q1 : int(1..4)])
+                Context #1: S_ExplicitVarSizeWithFlagsR2_Values[q1 + 1]
+            
+            CallStack (from HasCallStack):
+              error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+              bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+            cat: 408.solution: No such file or directory
+        was expecting:    
+    mildly_interesting.footballtennis_riddle:                                                         FAIL (5.43s)
+      Running
+      Checking stderr
+        src/test/Conjure/Custom.hs:86:
+        unexpected stderr:
+            Error: Cannot find executable glucose (for solver glucose)
+            Error: Cannot find executable glucose (for solver glucose)
+        was expecting:    
+    transform.function.partition.const_01:                                                            FAIL (3.72s)
+      Running
+      Checking stderr
+        src/test/Conjure/Custom.hs:86:
+        unexpected stderr:
+            conjure: This should never happen, sorry!
+            
+            However, it did happen, so it must be a bug. Please report it to us!
+            
+            Conjure is actively maintained, we will get back to you as soon as possible.
+            You can help us by providing a minimal failing example.
+            
+            Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+            
+            Issue tracker: http://github.com/conjure-cp/conjure/issues
+            
+            
+            
+            Not refined: m_PartitionAsSet_ExplicitR2[1] .< m_PartitionAsSet_ExplicitR2[2]
+            Not refined: m_PartitionAsSet_ExplicitR2
+            Domain     : matrix indexed by [int(1..2)] of set {Occurrence} (maxSize 4) of int(1..4)
+                Context #1: m_PartitionAsSet_ExplicitR2[1]
+                Context #2: m_PartitionAsSet_ExplicitR2[1] .< m_PartitionAsSet_ExplicitR2[2]
+                Context #1: m_PartitionAsSet_ExplicitR2[2]
+            
+            CallStack (from HasCallStack):
+              error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+              bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+            cat: 'conjure-output/*.solution': No such file or directory
+        was expecting:    
+    transform.function.partition.var_01:                                                              FAIL (3.88s)
+      Running
+      Checking stderr
+        src/test/Conjure/Custom.hs:86:
+        unexpected stderr:
+            conjure: This should never happen, sorry!
+            
+            However, it did happen, so it must be a bug. Please report it to us!
+            
+            Conjure is actively maintained, we will get back to you as soon as possible.
+            You can help us by providing a minimal failing example.
+            
+            Also include the repository version for this build: b15c6292f (2019-10-24 22:22:25 +0100)
+            
+            Issue tracker: http://github.com/conjure-cp/conjure/issues
+            
+            
+            
+            Not refined: m_PartitionAsSet_ExplicitR2[1] .< m_PartitionAsSet_ExplicitR2[2]
+            Not refined: m_PartitionAsSet_ExplicitR2
+            Domain     : matrix indexed by [int(1..2)] of set {Occurrence} (maxSize 4) of int(1..4)
+                Context #1: m_PartitionAsSet_ExplicitR2[1]
+                Context #2: m_PartitionAsSet_ExplicitR2[1] .< m_PartitionAsSet_ExplicitR2[2]
+                Context #1: m_PartitionAsSet_ExplicitR2[2]
+            Not refined: n_PartitionAsSet_ExplicitR2[1] .< n_PartitionAsSet_ExplicitR2[2]
+            Not refined: n_PartitionAsSet_ExplicitR2
+                Context #1: n_PartitionAsSet_ExplicitR2[1]
+                Context #2: n_PartitionAsSet_ExplicitR2[1] .< n_PartitionAsSet_ExplicitR2[2]
+                Context #1: n_PartitionAsSet_ExplicitR2[2]
+            
+            CallStack (from HasCallStack):
+              error, called at src/Conjure/Bug.hs:21:15 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.Bug
+              bug, called at src/Conjure/UI/Model.hs:950:26 in conjure-cp-2.3.0-FWo1VOaXtGF1VaO3bWN8bU:Conjure.UI.Model
+            cat: 'conjure-output/*.solution': No such file or directory
+        was expecting:    
+
+19 out of 2283 tests failed (386.50s)

--- a/tests/exhaustive/autogen/gen35/expected/model_1.eprime
+++ b/tests/exhaustive/autogen/gen35/expected/model_1.eprime
@@ -15,16 +15,18 @@ branching on
 such that
     and([q1 + 1 <= var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Marker ->
          flatten([([] : `matrix indexed by [int()] of int`),
-                  flatten([[-toInt(var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values_2_RelationAsMatrix
-                                       [q1, q15, q16])
-                                | q16 : bool]
+                  flatten([flatten([[-toInt(var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values_2_RelationAsMatrix
+                                                [q1, q15, q16]);
+                                         int(1)]
+                                        | q16 : bool])
                                | q15 : bool]);
                       int(1..2)])
          <lex
          flatten([([] : `matrix indexed by [int()] of int`),
-                  flatten([[-toInt(var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values_2_RelationAsMatrix
-                                       [q1 + 1, q18, q19])
-                                | q19 : bool]
+                  flatten([flatten([[-toInt(var2_FunctionAsRelationR8R16_RelationAsSetR8R16_ExplicitVarSizeWithMarkerR8R16_Values_2_RelationAsMatrix
+                                                [q1 + 1, q18, q19]);
+                                         int(1)]
+                                        | q19 : bool])
                                | q18 : bool]);
                       int(1..2)])
              | q1 : int(1..2)]),

--- a/tests/exhaustive/autogen/gen35/expected/model_2.eprime
+++ b/tests/exhaustive/autogen/gen35/expected/model_2.eprime
@@ -19,9 +19,10 @@ such that
                                 int(1)],
                            ([] : `matrix indexed by [int()] of int`);
                                int(1..2)]),
-                  flatten([[-toInt(var2_FunctionAsRelationR9R16_RelationAsSetR9R16_ExplicitVarSizeWithMarkerR9R16_Values_2_RelationAsMatrix
-                                       [q1, q14, q15])
-                                | q15 : bool]
+                  flatten([flatten([[-toInt(var2_FunctionAsRelationR9R16_RelationAsSetR9R16_ExplicitVarSizeWithMarkerR9R16_Values_2_RelationAsMatrix
+                                                [q1, q14, q15]);
+                                         int(1)]
+                                        | q15 : bool])
                                | q14 : bool]);
                       int(1..2)])
          <lex
@@ -30,9 +31,10 @@ such that
                                 int(1)],
                            ([] : `matrix indexed by [int()] of int`);
                                int(1..2)]),
-                  flatten([[-toInt(var2_FunctionAsRelationR9R16_RelationAsSetR9R16_ExplicitVarSizeWithMarkerR9R16_Values_2_RelationAsMatrix
-                                       [q1 + 1, q17, q18])
-                                | q18 : bool]
+                  flatten([flatten([[-toInt(var2_FunctionAsRelationR9R16_RelationAsSetR9R16_ExplicitVarSizeWithMarkerR9R16_Values_2_RelationAsMatrix
+                                                [q1 + 1, q17, q18]);
+                                         int(1)]
+                                        | q18 : bool])
                                | q17 : bool]);
                       int(1..2)])
              | q1 : int(1..2)]),

--- a/tests/exhaustive/autogen/gen37/expected/model_1.eprime
+++ b/tests/exhaustive/autogen/gen37/expected/model_1.eprime
@@ -12,15 +12,17 @@ branching on
      var1_RelationAsSetR5R8_ExplicitR5R8_2_ExplicitWithFlags_Values]
 such that
     flatten([flatten([[var1_RelationAsSetR5R8_ExplicitR5R8_1_ExplicitVarSizeWithMarker_Marker[1]; int(1)],
-                      [-toInt(var1_RelationAsSetR5R8_ExplicitR5R8_1_ExplicitVarSizeWithMarker_Values[1, q12])
-                           | q12 : int(1..2)];
+                      flatten([[-toInt(var1_RelationAsSetR5R8_ExplicitR5R8_1_ExplicitVarSizeWithMarker_Values[1, q12]);
+                                    int(1)]
+                                   | q12 : int(1..2)]);
                           int(1..2)]),
              ([] : `matrix indexed by [int()] of int`);
                  int(1..2)])
     <lex
     flatten([flatten([[var1_RelationAsSetR5R8_ExplicitR5R8_1_ExplicitVarSizeWithMarker_Marker[2]; int(1)],
-                      [-toInt(var1_RelationAsSetR5R8_ExplicitR5R8_1_ExplicitVarSizeWithMarker_Values[2, q14])
-                           | q14 : int(1..2)];
+                      flatten([[-toInt(var1_RelationAsSetR5R8_ExplicitR5R8_1_ExplicitVarSizeWithMarker_Values[2, q14]);
+                                    int(1)]
+                                   | q14 : int(1..2)]);
                           int(1..2)]),
              ([] : `matrix indexed by [int()] of int`);
                  int(1..2)]),

--- a/tests/exhaustive/autogen/gen37/expected/model_2.eprime
+++ b/tests/exhaustive/autogen/gen37/expected/model_2.eprime
@@ -13,8 +13,9 @@ branching on
      var1_RelationAsSetR5R9_ExplicitR5R9_2_ExplicitWithRepetition_Values]
 such that
     flatten([flatten([[var1_RelationAsSetR5R9_ExplicitR5R9_1_ExplicitVarSizeWithMarker_Marker[1]; int(1)],
-                      [-toInt(var1_RelationAsSetR5R9_ExplicitR5R9_1_ExplicitVarSizeWithMarker_Values[1, q11])
-                           | q11 : int(1..2)];
+                      flatten([[-toInt(var1_RelationAsSetR5R9_ExplicitR5R9_1_ExplicitVarSizeWithMarker_Values[1, q11]);
+                                    int(1)]
+                                   | q11 : int(1..2)]);
                           int(1..2)]),
              flatten([[var1_RelationAsSetR5R9_ExplicitR5R9_2_ExplicitWithRepetition_Flag[1]; int(1)],
                       ([] : `matrix indexed by [int()] of int`);
@@ -22,8 +23,9 @@ such that
                  int(1..2)])
     <lex
     flatten([flatten([[var1_RelationAsSetR5R9_ExplicitR5R9_1_ExplicitVarSizeWithMarker_Marker[2]; int(1)],
-                      [-toInt(var1_RelationAsSetR5R9_ExplicitR5R9_1_ExplicitVarSizeWithMarker_Values[2, q13])
-                           | q13 : int(1..2)];
+                      flatten([[-toInt(var1_RelationAsSetR5R9_ExplicitR5R9_1_ExplicitVarSizeWithMarker_Values[2, q13]);
+                                    int(1)]
+                                   | q13 : int(1..2)]);
                           int(1..2)]),
              flatten([[var1_RelationAsSetR5R9_ExplicitR5R9_2_ExplicitWithRepetition_Flag[2]; int(1)],
                       ([] : `matrix indexed by [int()] of int`);

--- a/tests/exhaustive/basic/partition_01/expected/model_2.eprime
+++ b/tests/exhaustive/basic/partition_01/expected/model_2.eprime
@@ -4,8 +4,8 @@ find x_PartitionAsSet_ExplicitR3_Explicit: matrix indexed by [int(1..2), int(1..
 branching on [x_PartitionAsSet_ExplicitR3_Explicit]
 such that
     allDiff([x_PartitionAsSet_ExplicitR3_Explicit[q12, q13] | q12 : int(1..2), q13 : int(1..3)]),
-    [x_PartitionAsSet_ExplicitR3_Explicit[1, q9] | q9 : int(1..3)] <lex
-    [x_PartitionAsSet_ExplicitR3_Explicit[2, q10] | q10 : int(1..3)],
+    flatten([[x_PartitionAsSet_ExplicitR3_Explicit[1, q9]; int(1)] | q9 : int(1..3)]) <lex
+    flatten([[x_PartitionAsSet_ExplicitR3_Explicit[2, q10]; int(1)] | q10 : int(1..3)]),
     and([and([x_PartitionAsSet_ExplicitR3_Explicit[q5, q6] < x_PartitionAsSet_ExplicitR3_Explicit[q5, q6 + 1]
                   | q6 : int(1..2)])
              | q5 : int(1..2)])

--- a/tests/exhaustive/basic/partition_02/expected/model_2.eprime
+++ b/tests/exhaustive/basic/partition_02/expected/model_2.eprime
@@ -12,8 +12,8 @@ such that
              | q20 : int(1..2), q21 : int(1..2)]),
     and([sum([toInt(x_PartitionAsSet_ExplicitR6_ExplicitVarSizeWithDummy[q26, q28] != 7) | q28 : int(1..6)]) >= 1
              | q26 : int(1..2)]),
-    [x_PartitionAsSet_ExplicitR6_ExplicitVarSizeWithDummy[1, q13] | q13 : int(1..6)] <lex
-    [x_PartitionAsSet_ExplicitR6_ExplicitVarSizeWithDummy[2, q14] | q14 : int(1..6)],
+    flatten([[x_PartitionAsSet_ExplicitR6_ExplicitVarSizeWithDummy[1, q13]; int(1)] | q13 : int(1..6)]) <lex
+    flatten([[x_PartitionAsSet_ExplicitR6_ExplicitVarSizeWithDummy[2, q14]; int(1)] | q14 : int(1..6)]),
     and([and([x_PartitionAsSet_ExplicitR6_ExplicitVarSizeWithDummy[q7, q8] <
               x_PartitionAsSet_ExplicitR6_ExplicitVarSizeWithDummy[q7, q8 + 1]
               \/ x_PartitionAsSet_ExplicitR6_ExplicitVarSizeWithDummy[q7, q8] = 7

--- a/tests/exhaustive/basic/partition_02/expected/model_3.eprime
+++ b/tests/exhaustive/basic/partition_02/expected/model_3.eprime
@@ -15,11 +15,13 @@ such that
              | q17 : int(1..2), q18 : int(1..2)]),
     and([x_PartitionAsSet_ExplicitR5_ExplicitVarSizeWithMarker_Marker[q19] >= 1 | q19 : int(1..2)]),
     flatten([[x_PartitionAsSet_ExplicitR5_ExplicitVarSizeWithMarker_Marker[1]; int(1)],
-             [x_PartitionAsSet_ExplicitR5_ExplicitVarSizeWithMarker_Values[1, q12] | q12 : int(1..6)];
+             flatten([[x_PartitionAsSet_ExplicitR5_ExplicitVarSizeWithMarker_Values[1, q12]; int(1)]
+                          | q12 : int(1..6)]);
                  int(1..2)])
     <lex
     flatten([[x_PartitionAsSet_ExplicitR5_ExplicitVarSizeWithMarker_Marker[2]; int(1)],
-             [x_PartitionAsSet_ExplicitR5_ExplicitVarSizeWithMarker_Values[2, q13] | q13 : int(1..6)];
+             flatten([[x_PartitionAsSet_ExplicitR5_ExplicitVarSizeWithMarker_Values[2, q13]; int(1)]
+                          | q13 : int(1..6)]);
                  int(1..2)]),
     and([and([q8 + 1 <= x_PartitionAsSet_ExplicitR5_ExplicitVarSizeWithMarker_Marker[q7] ->
               x_PartitionAsSet_ExplicitR5_ExplicitVarSizeWithMarker_Values[q7, q8] <

--- a/tests/exhaustive/basic/partition_03/expected/model_2.eprime
+++ b/tests/exhaustive/basic/partition_03/expected/model_2.eprime
@@ -10,8 +10,10 @@ such that
                              | q14 : int(1..6), q15 : int(1..3)],
                         0),
     and([q4 + 1 <= x_PartitionAsSet_ExplicitVarSizeWithMarkerR3_Marker ->
-         [x_PartitionAsSet_ExplicitVarSizeWithMarkerR3_Values_Explicit[q4, q10] | q10 : int(1..3)] <lex
-         [x_PartitionAsSet_ExplicitVarSizeWithMarkerR3_Values_Explicit[q4 + 1, q11] | q11 : int(1..3)]
+         flatten([[x_PartitionAsSet_ExplicitVarSizeWithMarkerR3_Values_Explicit[q4, q10]; int(1)] | q10 : int(1..3)])
+         <lex
+         flatten([[x_PartitionAsSet_ExplicitVarSizeWithMarkerR3_Values_Explicit[q4 + 1, q11]; int(1)]
+                      | q11 : int(1..3)])
              | q4 : int(1..5)]),
     and([q5 > x_PartitionAsSet_ExplicitVarSizeWithMarkerR3_Marker ->
          and([x_PartitionAsSet_ExplicitVarSizeWithMarkerR3_Values_Explicit[q5, q13] = 1 | q13 : int(1..3)])

--- a/tests/exhaustive/basic/relation05_set_fixed_direct/expected/model_2.eprime
+++ b/tests/exhaustive/basic/relation05_set_fixed_direct/expected/model_2.eprime
@@ -5,11 +5,11 @@ find x_RelationAsSetR3_ExplicitR3_2_Explicit: matrix indexed by [int(1..4), int(
 branching on [x_RelationAsSetR3_ExplicitR3_1, x_RelationAsSetR3_ExplicitR3_2_Explicit]
 such that
     and([flatten([[x_RelationAsSetR3_ExplicitR3_1[q1]; int(1)],
-                  [x_RelationAsSetR3_ExplicitR3_2_Explicit[q1, q5] | q5 : int(1..2)];
+                  flatten([[x_RelationAsSetR3_ExplicitR3_2_Explicit[q1, q5]; int(1)] | q5 : int(1..2)]);
                       int(1..2)])
          <lex
          flatten([[x_RelationAsSetR3_ExplicitR3_1[q1 + 1]; int(1)],
-                  [x_RelationAsSetR3_ExplicitR3_2_Explicit[q1 + 1, q6] | q6 : int(1..2)];
+                  flatten([[x_RelationAsSetR3_ExplicitR3_2_Explicit[q1 + 1, q6]; int(1)] | q6 : int(1..2)]);
                       int(1..2)])
              | q1 : int(1..3)]),
     and([x_RelationAsSetR3_ExplicitR3_2_Explicit[q2, 1] < x_RelationAsSetR3_ExplicitR3_2_Explicit[q2, 2]

--- a/tests/exhaustive/basic/relation05_set_fixed_setty/expected/model_2.eprime
+++ b/tests/exhaustive/basic/relation05_set_fixed_setty/expected/model_2.eprime
@@ -4,8 +4,12 @@ find x_ExplicitR3_1: matrix indexed by [int(1..4)] of int(1..2)
 find x_ExplicitR3_2_Explicit: matrix indexed by [int(1..4), int(1..2)] of int(1..3)
 branching on [x_ExplicitR3_1, x_ExplicitR3_2_Explicit]
 such that
-    and([flatten([[x_ExplicitR3_1[q1]; int(1)], [x_ExplicitR3_2_Explicit[q1, q5] | q5 : int(1..2)]; int(1..2)]) <lex
-         flatten([[x_ExplicitR3_1[q1 + 1]; int(1)], [x_ExplicitR3_2_Explicit[q1 + 1, q6] | q6 : int(1..2)]; int(1..2)])
+    and([flatten([[x_ExplicitR3_1[q1]; int(1)], flatten([[x_ExplicitR3_2_Explicit[q1, q5]; int(1)] | q5 : int(1..2)]);
+                      int(1..2)])
+         <lex
+         flatten([[x_ExplicitR3_1[q1 + 1]; int(1)],
+                  flatten([[x_ExplicitR3_2_Explicit[q1 + 1, q6]; int(1)] | q6 : int(1..2)]);
+                      int(1..2)])
              | q1 : int(1..3)]),
     and([x_ExplicitR3_2_Explicit[q2, 1] < x_ExplicitR3_2_Explicit[q2, 2] | q2 : int(1..4)])
 

--- a/tests/exhaustive/basic/relation06_set_bounded_direct/expected/model_2.eprime
+++ b/tests/exhaustive/basic/relation06_set_bounded_direct/expected/model_2.eprime
@@ -10,11 +10,13 @@ branching on
 such that
     and([q1 + 1 <= x_RelationAsSetR3_ExplicitVarSizeWithMarkerR3_Marker ->
          flatten([[x_RelationAsSetR3_ExplicitVarSizeWithMarkerR3_Values_1[q1]; int(1)],
-                  [x_RelationAsSetR3_ExplicitVarSizeWithMarkerR3_Values_2_Explicit[q1, q6] | q6 : int(1..2)];
+                  flatten([[x_RelationAsSetR3_ExplicitVarSizeWithMarkerR3_Values_2_Explicit[q1, q6]; int(1)]
+                               | q6 : int(1..2)]);
                       int(1..2)])
          <lex
          flatten([[x_RelationAsSetR3_ExplicitVarSizeWithMarkerR3_Values_1[q1 + 1]; int(1)],
-                  [x_RelationAsSetR3_ExplicitVarSizeWithMarkerR3_Values_2_Explicit[q1 + 1, q7] | q7 : int(1..2)];
+                  flatten([[x_RelationAsSetR3_ExplicitVarSizeWithMarkerR3_Values_2_Explicit[q1 + 1, q7]; int(1)]
+                               | q7 : int(1..2)]);
                       int(1..2)])
              | q1 : int(1..2)]),
     and([q2 > x_RelationAsSetR3_ExplicitVarSizeWithMarkerR3_Marker ->

--- a/tests/exhaustive/basic/relation06_set_bounded_setty/expected/model_2.eprime
+++ b/tests/exhaustive/basic/relation06_set_bounded_setty/expected/model_2.eprime
@@ -9,11 +9,11 @@ branching on
 such that
     and([q1 + 1 <= x_ExplicitVarSizeWithMarkerR3_Marker ->
          flatten([[x_ExplicitVarSizeWithMarkerR3_Values_1[q1]; int(1)],
-                  [x_ExplicitVarSizeWithMarkerR3_Values_2_Explicit[q1, q6] | q6 : int(1..2)];
+                  flatten([[x_ExplicitVarSizeWithMarkerR3_Values_2_Explicit[q1, q6]; int(1)] | q6 : int(1..2)]);
                       int(1..2)])
          <lex
          flatten([[x_ExplicitVarSizeWithMarkerR3_Values_1[q1 + 1]; int(1)],
-                  [x_ExplicitVarSizeWithMarkerR3_Values_2_Explicit[q1 + 1, q7] | q7 : int(1..2)];
+                  flatten([[x_ExplicitVarSizeWithMarkerR3_Values_2_Explicit[q1 + 1, q7]; int(1)] | q7 : int(1..2)]);
                       int(1..2)])
              | q1 : int(1..2)]),
     and([q2 > x_ExplicitVarSizeWithMarkerR3_Marker ->

--- a/tests/exhaustive/basic/relation06_set_bounded_setty/expected/model_4.eprime
+++ b/tests/exhaustive/basic/relation06_set_bounded_setty/expected/model_4.eprime
@@ -9,11 +9,11 @@ branching on
 such that
     and([x_ExplicitVarSizeWithFlagsR3_Flags[q1 + 1] ->
          flatten([[x_ExplicitVarSizeWithFlagsR3_Values_1[q1]; int(1)],
-                  [x_ExplicitVarSizeWithFlagsR3_Values_2_Explicit[q1, q8] | q8 : int(1..2)];
+                  flatten([[x_ExplicitVarSizeWithFlagsR3_Values_2_Explicit[q1, q8]; int(1)] | q8 : int(1..2)]);
                       int(1..2)])
          <lex
          flatten([[x_ExplicitVarSizeWithFlagsR3_Values_1[q1 + 1]; int(1)],
-                  [x_ExplicitVarSizeWithFlagsR3_Values_2_Explicit[q1 + 1, q9] | q9 : int(1..2)];
+                  flatten([[x_ExplicitVarSizeWithFlagsR3_Values_2_Explicit[q1 + 1, q9]; int(1)] | q9 : int(1..2)]);
                       int(1..2)])
              | q1 : int(1..2)]),
     and([x_ExplicitVarSizeWithFlagsR3_Flags[q2] = false ->

--- a/tests/exhaustive/basic/setOfSet03/expected/model_2.eprime
+++ b/tests/exhaustive/basic/setOfSet03/expected/model_2.eprime
@@ -3,6 +3,7 @@ language ESSENCE' 1.0
 find x_ExplicitR3_Explicit: matrix indexed by [int(1..2), int(1..3)] of int(1..4)
 branching on [x_ExplicitR3_Explicit]
 such that
-    [x_ExplicitR3_Explicit[1, q5] | q5 : int(1..3)] <lex [x_ExplicitR3_Explicit[2, q6] | q6 : int(1..3)],
+    flatten([[x_ExplicitR3_Explicit[1, q5]; int(1)] | q5 : int(1..3)]) <lex
+    flatten([[x_ExplicitR3_Explicit[2, q6]; int(1)] | q6 : int(1..3)]),
     and([and([x_ExplicitR3_Explicit[q2, q3] < x_ExplicitR3_Explicit[q2, q3 + 1] | q3 : int(1..2)]) | q2 : int(1..2)])
 

--- a/tests/exhaustive/basic/variant01/expected/model_1.eprime
+++ b/tests/exhaustive/basic/variant01/expected/model_1.eprime
@@ -9,13 +9,15 @@ branching on
      x_ExplicitVarSizeWithMarker_Values_theBool, x_ExplicitVarSizeWithMarker_Values_theInt]
 such that
     and([q1 + 1 <= x_ExplicitVarSizeWithMarker_Marker ->
-         [x_ExplicitVarSizeWithMarker_Values__tag[q1], -toInt(x_ExplicitVarSizeWithMarker_Values_theBool[q1]),
-          x_ExplicitVarSizeWithMarker_Values_theInt[q1];
-              int(1..3)]
+         flatten([[x_ExplicitVarSizeWithMarker_Values__tag[q1]; int(1)],
+                  [-toInt(x_ExplicitVarSizeWithMarker_Values_theBool[q1]); int(1)],
+                  [x_ExplicitVarSizeWithMarker_Values_theInt[q1]; int(1)];
+                      int(1..3)])
          <lex
-         [x_ExplicitVarSizeWithMarker_Values__tag[q1 + 1], -toInt(x_ExplicitVarSizeWithMarker_Values_theBool[q1 + 1]),
-          x_ExplicitVarSizeWithMarker_Values_theInt[q1 + 1];
-              int(1..3)]
+         flatten([[x_ExplicitVarSizeWithMarker_Values__tag[q1 + 1]; int(1)],
+                  [-toInt(x_ExplicitVarSizeWithMarker_Values_theBool[q1 + 1]); int(1)],
+                  [x_ExplicitVarSizeWithMarker_Values_theInt[q1 + 1]; int(1)];
+                      int(1..3)])
              | q1 : int(1..3)]),
     and([q2 > x_ExplicitVarSizeWithMarker_Marker ->
          and([x_ExplicitVarSizeWithMarker_Values__tag[q2] = 1, x_ExplicitVarSizeWithMarker_Values_theBool[q2] = false,

--- a/tests/exhaustive/basic/variant01/expected/model_2.eprime
+++ b/tests/exhaustive/basic/variant01/expected/model_2.eprime
@@ -9,13 +9,15 @@ branching on
      x_ExplicitVarSizeWithFlags_Values_theBool, x_ExplicitVarSizeWithFlags_Values_theInt]
 such that
     and([x_ExplicitVarSizeWithFlags_Flags[q1 + 1] ->
-         [x_ExplicitVarSizeWithFlags_Values__tag[q1], -toInt(x_ExplicitVarSizeWithFlags_Values_theBool[q1]),
-          x_ExplicitVarSizeWithFlags_Values_theInt[q1];
-              int(1..3)]
+         flatten([[x_ExplicitVarSizeWithFlags_Values__tag[q1]; int(1)],
+                  [-toInt(x_ExplicitVarSizeWithFlags_Values_theBool[q1]); int(1)],
+                  [x_ExplicitVarSizeWithFlags_Values_theInt[q1]; int(1)];
+                      int(1..3)])
          <lex
-         [x_ExplicitVarSizeWithFlags_Values__tag[q1 + 1], -toInt(x_ExplicitVarSizeWithFlags_Values_theBool[q1 + 1]),
-          x_ExplicitVarSizeWithFlags_Values_theInt[q1 + 1];
-              int(1..3)]
+         flatten([[x_ExplicitVarSizeWithFlags_Values__tag[q1 + 1]; int(1)],
+                  [-toInt(x_ExplicitVarSizeWithFlags_Values_theBool[q1 + 1]); int(1)],
+                  [x_ExplicitVarSizeWithFlags_Values_theInt[q1 + 1]; int(1)];
+                      int(1..3)])
              | q1 : int(1..3)]),
     and([x_ExplicitVarSizeWithFlags_Flags[q2] = false ->
          and([x_ExplicitVarSizeWithFlags_Values__tag[q2] = 1, x_ExplicitVarSizeWithFlags_Values_theBool[q2] = false,

--- a/tests/exhaustive/issues/182/expected/model.eprime
+++ b/tests/exhaustive/issues/182/expected/model.eprime
@@ -28,17 +28,19 @@ such that
              | q28 : int(1..4)]),
     and([q4 + 1 <= p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Marker ->
          flatten([[p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values_ExplicitVarSizeWithMarker_Marker[q4]; int(1)],
-                  flatten([[p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values_ExplicitVarSizeWithMarker_Values
-                                [q4, q12, q13]
-                                | q13 : int(1..2)]
+                  flatten([flatten([[p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values_ExplicitVarSizeWithMarker_Values
+                                         [q4, q12, q13];
+                                         int(1)]
+                                        | q13 : int(1..2)])
                                | q12 : int(1..4)]);
                       int(1..2)])
          <lex
          flatten([[p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values_ExplicitVarSizeWithMarker_Marker[q4 + 1];
                        int(1)],
-                  flatten([[p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values_ExplicitVarSizeWithMarker_Values
-                                [q4 + 1, q14, q15]
-                                | q15 : int(1..2)]
+                  flatten([flatten([[p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values_ExplicitVarSizeWithMarker_Values
+                                         [q4 + 1, q14, q15];
+                                         int(1)]
+                                        | q15 : int(1..2)])
                                | q14 : int(1..4)]);
                       int(1..2)])
              | q4 : int(1..3)]),
@@ -51,11 +53,15 @@ such that
     p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Marker <= 4,
     and([q6 <= p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Marker ->
          and([q7 + 1 <= p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values_ExplicitVarSizeWithMarker_Marker[q6] ->
-              [p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values_ExplicitVarSizeWithMarker_Values[q6, q7, q18]
-                   | q18 : int(1..2)]
+              flatten([[p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values_ExplicitVarSizeWithMarker_Values
+                            [q6, q7, q18];
+                            int(1)]
+                           | q18 : int(1..2)])
               <lex
-              [p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values_ExplicitVarSizeWithMarker_Values[q6, q7 + 1, q19]
-                   | q19 : int(1..2)]
+              flatten([[p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Values_ExplicitVarSizeWithMarker_Values
+                            [q6, q7 + 1, q19];
+                            int(1)]
+                           | q19 : int(1..2)])
                   | q7 : int(1..3)])
              | q6 : int(1..4)]),
     and([q6 <= p_PartitionAsSet_ExplicitVarSizeWithMarkerR5_Marker ->


### PR DESCRIPTION
This moves the flattening operation required for .< into the symmetry representation method. Fixing #456 