### PR TITLE
Remove comment files from JSON output, so the file is a valid stream of JSON objects

### DIFF
--- a/src/Conjure/UI/MainHelper.hs
+++ b/src/Conjure/UI/MainHelper.hs
@@ -977,7 +977,6 @@ srStdoutHandler
                             appendFile filenameEssenceSol ("$ Solution: " ++ padLeft 6 '0' (show solutionNumber) ++ "\n")
                             appendFile filenameEssenceSol (render lineWidth essenceSol ++ "\n\n")
                             when (outputFormat == JSON) $ do
-                                appendFile filenameEssenceSolJSON  ("$ Solution: " ++ padLeft 6 '0' (show solutionNumber) ++ "\n")
                                 essenceSol' <- toSimpleJSON essenceSol
                                 appendFile filenameEssenceSolJSON (render lineWidth essenceSol')
                                 appendFile filenameEssenceSolJSON  ("\n")


### PR DESCRIPTION
At the moment the JSON file isn't valid JSON, as it contains $ comments

With this change the whole file isn't a single JSON object, but a stream of JSON objects -- some languages (including GAP) are happy reading such a stream.