### PR TITLE
Print message to stderr, to make it easier to skip

### DIFF
--- a/etc/build/install-gecode.sh
+++ b/etc/build/install-gecode.sh
@@ -14,7 +14,7 @@ git checkout release-6.0.1
 mkdir build
 cd build
 ../configure --disable-qt --disable-gist --enable-static
-make -j
+make -j4
 cp tools/flatzinc/fzn-gecode ${BIN_DIR}/fzn-gecode
 echo "gecode executable is at ${BIN_DIR}/fzn-gecode"
 ls -l ${BIN_DIR}/fzn-gecode

--- a/src/Conjure/UI/MainHelper.hs
+++ b/src/Conjure/UI/MainHelper.hs
@@ -39,7 +39,7 @@ import Conjure.Language.ModelStats ( modelDeclarationsJSON )
 import Conjure.Language.AdHoc ( toSimpleJSON )
 
 -- base
-import System.IO ( Handle, hSetBuffering, stdout, BufferMode(..) )
+import System.IO ( Handle, hSetBuffering, stdout, BufferMode(..), hPutStrLn, stderr )
 import System.Environment ( getEnvironment )
 import System.Info ( os )
 import GHC.Conc ( numCapabilities )
@@ -148,7 +148,7 @@ mainWithArgs Pretty{..} = do
     model0 <- if or [ s `isSuffixOf` essence
                     | s <- [".param", ".eprime-param", ".solution", ".eprime.solution"] ]
                 then do
-                    liftIO $ putStrLn "Parsing as a parameter file"
+                    liftIO $ hPutStrLn stderr "Parsing as a parameter file"
                     readParamOrSolutionFromFile essence
                 else readModelFromFile essence
     let model1 = model0

--- a/tests/custom/issues/478/stderr.expected
+++ b/tests/custom/issues/478/stderr.expected
@@ -1,0 +1,1 @@
+Parsing as a parameter file

--- a/tests/custom/issues/478/stdout.expected
+++ b/tests/custom/issues/478/stdout.expected
@@ -1,4 +1,3 @@
-Parsing as a parameter file
 {"goal": {"at_": [], "fuel": [], "in_": [], "onboard": [[2, -65536]], "total_fuel_used": []},
  "init":
      {"at_":


### PR DESCRIPTION
At the moment the 'JSON' pretty printing sometimes prints a message (when it is given a solution, or param). The problem is, this message makes the output invalid JSON.

Therefore, instead print the message to stderr. This will make the output the same for the terminal reader, but mean anyone who cares can redirect stderr to /dev/null