### PR TITLE
Escape more characters in JSON output. Fixes #517

### DIFF
--- a/src/Conjure/Language/Pretty.hs
+++ b/src/Conjure/Language/Pretty.hs
@@ -22,7 +22,7 @@ import Conjure.Prelude
 import Text.Printf ( printf )
 
 -- text
-import qualified Data.Text as T ( Text, unpack, replace, length )
+import qualified Data.Text as T ( Text, unpack, length, singleton, concatMap )
 
 -- pretty
 import Text.PrettyPrint
@@ -114,10 +114,19 @@ prettyContext = map (\ (a,b) -> nest 4 $ pretty a <> ":" <+> pretty b )
 -- JSON ------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
+-- Not exhaustive, just the ones that are 
+-- likely to appear and cause trouble in output.
+jsonEsc :: Char -> Text
+jsonEsc '"' = "\\\""
+jsonEsc '\\' = "\\\\"
+jsonEsc '\r' = "\\r"
+jsonEsc '\n' = "\\n"
+jsonEsc c = T.singleton c
+
 instance Pretty JSON.Value where
     pretty (Object x) = pretty x
     pretty (Array x) = pretty x
-    pretty (String x) = "\"" <> pretty (T.unpack (T.replace "\"" "\\\"" x)) <> "\""
+    pretty (String x) = "\"" <> pretty (T.unpack (T.concatMap jsonEsc x)) <> "\""
     pretty (Number x) = pretty x
     pretty (Bool False) = "false"
     pretty (Bool True) = "true"

--- a/tests/custom/issues/517/517.essence
+++ b/tests/custom/issues/517/517.essence
@@ -1,0 +1,9 @@
+$ The variant triggers refinement output that is vulnerable to the bug
+find x : variant {i:int(1..3),b:bool}
+$ The backslash at the end of the next line doesn't get eacaped, producing "... /\"
+such that active(x,i) -> x[i]>2 /\
+x[i]<5
+
+$ Simpler cases that fail since `\ ` isn't a valid JSON escape sequence
+find y:bool such that y /\ true
+find z:bool such that and([z,true])

--- a/tests/custom/issues/517/run.sh
+++ b/tests/custom/issues/517/run.sh
@@ -1,3 +1,3 @@
-rm -rf conjure-output
+rm -rf conjure-output *.solution
 conjure solve --verbose-trail --rewrites-trail 517.essence 2>&1 | grep "Malformed JSON in a cached Essence Prime model."
-rm -rf conjure-output
+rm -rf conjure-output *.solution

--- a/tests/custom/issues/517/run.sh
+++ b/tests/custom/issues/517/run.sh
@@ -1,0 +1,3 @@
+rm -rf conjure-output
+conjure solve --verbose-trail --rewrites-trail 517.essence 2>&1 | grep "Malformed JSON in a cached Essence Prime model."
+rm -rf conjure-output


### PR DESCRIPTION
#517 

Disclaimer: This was implemented entirely using GitHub Codespaces (without sufficient RAM to build the whole project) on my mobile phone during toilet breaks with zero experience in Haskell. Please be gentle!