### PR TITLE
correct underlines for stricter RST syntax checking in recent sphinx-doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinxcontrib.bibtex',
 ]
+bibtex_bibfiles = ['refs.bib']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -68,7 +69,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+#language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/tutorials/knapsack_generator/KnapGen.rst
+++ b/docs/tutorials/knapsack_generator/KnapGen.rst
@@ -1,5 +1,5 @@
 Handcrafting Instance Generators in Essence
-------------------
+-------------------------------------------
 
 *Authors: Joan Espasa Arxer and Christopher Stone*
 
@@ -7,7 +7,7 @@ In modelling it is common to create an abstract model that expects some input pa
 In this tutorial we demonstrate how to use ESSENCE to handcraft a generator of instances that can be used to produce input parameters for a specific model.
 
 Instances for the Knapsack problem
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Here is the model of the Knapsack Problem from (<link to other tutorial>) - knapsack.essence
 
 .. code-block:: essence


### PR DESCRIPTION
Sphinx-doc 5.x now wants underlines in RST files to match the length of the heading.