### PR TITLE
upgrade to Sphinx-5.x and document requirements

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Conjure'
-copyright = u'2009-2019, Conjure developers'
+copyright = u'2009–2022, Conjure developers'
 author = u'Özgür Akgün, Saad Attieh, Juliana Bowles, Nguyen Dang, Joan Espasa Arxer, Jordina Francès de Mas, Ian Gent, Ruth Hoffmann, Chris Jefferson, Gökberk Koçak, Alice Lynch, Ian Miguel, András Salamon and Christopher Stone'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -384,6 +384,6 @@ inline_highlight_literals = True
 
 def setup(sphinx):
     from BNFLexer import BNFLexer
-    sphinx.add_lexer("bnf", BNFLexer())
+    sphinx.add_lexer("bnf", BNFLexer)
     from EssenceLexer import EssenceLexer
-    sphinx.add_lexer("essence", EssenceLexer())
+    sphinx.add_lexer("essence", EssenceLexer)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -57,3 +57,21 @@ Savile Row can be downloaded from `its website <http://savilerow.cs.st-andrews.a
 You do not need to download Savile Row separately when you compile Conjure from source.
 An up-to-date version of Savile Row is also copied next to the Conjure executable.
 
+
+Compiling the documentation
+---------------------------
+
+The Makefile target `docs` builds the manual in PDF and HTML format.
+This requires some Python packages to already be installed.
+With a recent Python 3 the following should work to install the needed Python dependencies:
+
+.. code-block:: bash
+
+    pip3 install sphinx-rtd-theme sphinxcontrib-bibtex
+
+Without specifying versions this currently installs Sphinx-5.x and recent versions of related dependencies.
+However, ``sphinx-rtd-theme`` forces ``opendoc < 0.18`` rather than a more recent version.
+Some packages used by ``sphinxcontrib-bibtex`` also seem to require an older version ``opendoc`` but do not explicitly declare this dependency, and just running ``pip3 install sphinxcontrib-bibtex`` will install packages which cannot successfully build the PDF documentation.
+
+The PDF target needs a fairly comprehensive TeX installation, with many styles and fonts beyond a minimal installation.
+The default packages installed by MacTeX should work on macOS.


### PR DESCRIPTION
As documented in issue #523 the documentation currently may fail to build on recent systems. The automated build testing system and the system used by `readthedocs.org` seem to be using an older version Sphinx-2.x rather than current Sphinx-5.x so this isn't necessarily obvious to most people, but will likely become a problem if either or both of these systems upgrade to a more recent toolchain.

Here I have documented the minimal pip3 command needed, and mentioned the TeX requirements, also fixing the incompatibility in `conf.py` which prevented `make docs` working: in Sphinx-3.x the `add_lexer` API changed to require a class rather than a function.

I think this should still work on a reasonably recent Sphinx-2.x toolchain as the API apparently allowed both calling conventions during that era.
In particular, I'm hoping that `readthedocs.org` and the build test systems continue working.
However, I haven't tested with an older Sphinx as I haven't been able to establish the precise older versions it implicitly needs.
After a couple of hours trying I gave up on trying to get Sphinx-2.x working on Python 3.10.