### PR TITLE
replace which by command as per POSIX

### DIFF
--- a/etc/build/install-z3.sh
+++ b/etc/build/install-z3.sh
@@ -19,7 +19,7 @@ pushd tmp-install-z3
 download https://github.com/Z3Prover/z3/archive/z3-$ZSH_VERSION.tar.gz
 tar xzf z3-$ZSH_VERSION.tar.gz
 cd z3-z3-$ZSH_VERSION
-PYTHON=`which python 2> /dev/null || true`
+PYTHON=`command -v python 2> /dev/null || true`
 PYTHON=${PYTHON:-python3}
 $PYTHON scripts/mk_make.py --prefix=${BIN_DIR}
 cd build


### PR DESCRIPTION
This replaces my previous use of `which` by `command -v` in the Python detection code as per https://stackoverflow.com/questions/592620/how-can-i-check-if-a-program-exists-from-a-bash-script to hopefully make the Z3 build more portable.