### PR TITLE
Monadfail migration

### DIFF
--- a/conjure-cp.cabal
+++ b/conjure-cp.cabal
@@ -326,7 +326,6 @@ Library
         OverloadedStrings
         ScopedTypeVariables
         TypeOperators
-        -- NoMonadFailDesugaring
         ViewPatterns
     ghc-options:
         -O2

--- a/conjure-cp.cabal
+++ b/conjure-cp.cabal
@@ -326,7 +326,7 @@ Library
         OverloadedStrings
         ScopedTypeVariables
         TypeOperators
-        NoMonadFailDesugaring
+        -- NoMonadFailDesugaring
         ViewPatterns
     ghc-options:
         -O2

--- a/etc/build/gen_Expression.hs
+++ b/etc/build/gen_Expression.hs
@@ -35,7 +35,7 @@ main = do
                 [ [ "instance Op" ++ m ++ " Expression :< Expression where"
                   , "    inject = Op . MkOp" ++ m
                   , "    project (Op (MkOp" ++ m ++ " x)) = return x"
-                  , "    project _ = fail \"projecting Op" ++ m ++ "\""
+                  , "    project _ = failDoc \"projecting Op" ++ m ++ "\""
                   ]
                 | m <- operators
                 ]

--- a/etc/build/gen_Operator.hs
+++ b/etc/build/gen_Operator.hs
@@ -59,7 +59,7 @@ main = do
                 [ [ "instance Op" ++ m ++ " x :< Op x where"
                   , "    inject = MkOp" ++ m
                   , "    project (MkOp" ++ m ++ " x) = return x"
-                  , "    project _ = fail \"projecting Op" ++ m ++ "\""
+                  , "    project _ = failDoc \"projecting Op" ++ m ++ "\""
                   ]
                 | m <- operators
                 ]

--- a/etc/build/record-coverage.sh
+++ b/etc/build/record-coverage.sh
@@ -2,9 +2,9 @@
 
 set -o errexit
 
-if ${COVERAGE} && [ -z $DOWNLOADSECUREFILE_SECUREFILEPATH ]; then
+if ${COVERAGE} && [ -n "$DOWNLOADSECUREFILE_SECUREFILEPATH" ]; then
     # this is from https://cloudblogs.microsoft.com/opensource/2019/04/05/publishing-github-pages-from-azure-pipelines
-    mkdir ~/.ssh && mv $DOWNLOADSECUREFILE_SECUREFILEPATH ~/.ssh/id_rsa
+    mkdir ~/.ssh && mv "$DOWNLOADSECUREFILE_SECUREFILEPATH" ~/.ssh/id_rsa
     chmod 700 ~/.ssh && chmod 600 ~/.ssh/id_rsa
     ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
     git clone git@github.com:conjure-cp/conjure-code-coverage.git
@@ -19,7 +19,7 @@ if ${COVERAGE} && [ -z $DOWNLOADSECUREFILE_SECUREFILEPATH ]; then
 
     # rename the cryptic directory name for better diffs over time
     conjureDirName=$(cd conjure-code-coverage/latest ; ls | grep conjure-cp)
-    mv conjure-code-coverage/latest/${conjureDirName} conjure-code-coverage/latest/conjure-cp
+    mv conjure-code-coverage/latest/"${conjureDirName}" conjure-code-coverage/latest/conjure-cp
 
     # search & replace to fix links
     find conjure-code-coverage/latest -type f -exec sed -i "s/${conjureDirName}/conjure-cp/g" {} \;

--- a/src/Conjure/Bug.hs
+++ b/src/Conjure/Bug.hs
@@ -43,5 +43,5 @@ bugFailT loc comp = do
         Left err -> bug (vcat ["BUGFAIL at" <+> loc, err])
         Right x  -> return x
 
-instance MonadFail IO where
-    fail msg = bug (vcat ["IO Error", msg])
+instance MonadFailDoc IO where
+    failDoc msg = bug (vcat ["IO Error", msg])

--- a/src/Conjure/Compute/DomainOf.hs
+++ b/src/Conjure/Compute/DomainOf.hs
@@ -11,6 +11,7 @@ import Conjure.Language
 import Conjure.Language.Domain ( HasRepresentation(..) )
 import Conjure.Language.RepresentationOf ( RepresentationOf(..) )
 import Conjure.Compute.DomainUnion
+import Conjure.Language.Expression.Op.Internal.Common (getIntTag)
 
 
 type Dom = Domain () Expression
@@ -20,6 +21,7 @@ class DomainOf a where
     -- | calculate the domain of `a`
     domainOf ::
         MonadFail m =>
+        MonadFailDoc m =>
         NameGen m =>
         (?typeCheckerMode :: TypeCheckerMode) =>
         a -> m Dom
@@ -31,6 +33,7 @@ class DomainOf a where
     --   but sometimes it is better to implement this directly.
     indexDomainsOf ::
         MonadFail m =>
+        MonadFailDoc m =>
         NameGen m =>
         Pretty a =>
         (?typeCheckerMode :: TypeCheckerMode) =>
@@ -42,6 +45,7 @@ domainOfR ::
     DomainOf a =>
     RepresentationOf a =>
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
     a -> m (Domain HasRepresentation Expression)
@@ -53,6 +57,7 @@ domainOfR inp = do
 
 defIndexDomainsOf ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     DomainOf a =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -69,11 +74,11 @@ instance DomainOf ReferenceTo where
     domainOf (InComprehension (GenDomainNoRepr Single{} dom)) = return dom
     domainOf (InComprehension (GenDomainHasRepr _ dom)) = return (forgetRepr dom)
     domainOf (InComprehension (GenInExpr Single{} x)) = domainOf x >>= innerDomainOf
-    domainOf x@InComprehension{} = fail $ vcat [ "domainOf-ReferenceTo-InComprehension", pretty x, pretty (show x) ]
+    domainOf x@InComprehension{} = failDoc $ vcat [ "domainOf-ReferenceTo-InComprehension", pretty x, pretty (show x) ]
     domainOf (DeclNoRepr  _ _ dom _) = return dom
     domainOf (DeclHasRepr _ _ dom  ) = return (forgetRepr dom)
-    domainOf RecordField{}  = fail "domainOf-ReferenceTo-RecordField"
-    domainOf VariantField{} = fail "domainOf-ReferenceTo-VariantField"
+    domainOf RecordField{}  = failDoc "domainOf-ReferenceTo-RecordField"
+    domainOf VariantField{} = failDoc "domainOf-ReferenceTo-VariantField"
 
 
 instance DomainOf Expression where
@@ -85,7 +90,7 @@ instance DomainOf Expression where
     domainOf (Comprehension h _) = do
         domH <- domainOf h
         return $ DomainMatrix (DomainInt TagInt [RangeLowerBounded 1]) domH
-    domainOf x = fail ("domainOf{Expression}:" <+> pretty (show x))
+    domainOf x = failDoc ("domainOf{Expression}:" <+> pretty (show x))
 
     -- if an empty matrix literal has a type annotation
     indexDomainsOf (Typed lit ty) | emptyCollectionX lit =
@@ -100,7 +105,7 @@ instance DomainOf Expression where
     indexDomainsOf (AbstractLiteral x) = indexDomainsOf x
     indexDomainsOf (Op x) = indexDomainsOf x
     indexDomainsOf (WithLocals h _) = indexDomainsOf h
-    indexDomainsOf x = fail ("indexDomainsOf{Expression}:" <+> pretty (show x))
+    indexDomainsOf x = failDoc ("indexDomainsOf{Expression}:" <+> pretty (show x))
 
 -- this should be better implemented by some ghc-generics magic
 instance (DomainOf x, TypeOf x, Pretty x, ExpressionLike x, Domain () x :< x, Dom :< x) => DomainOf (Op x) where
@@ -262,12 +267,12 @@ instance DomainOf Constant where
     domainOf ConstantBool{}             = return DomainBool
     domainOf i@(ConstantInt t _)        = return $ DomainInt t [RangeSingle (Constant i)]
     domainOf (ConstantEnum defn _ _ )   = return (DomainEnum defn Nothing Nothing)
-    domainOf ConstantField{}            = fail "DomainOf-ConstantField"
+    domainOf ConstantField{}            = failDoc "DomainOf-ConstantField"
     domainOf (ConstantAbstract x)       = domainOf (fmap Constant x)
     domainOf (DomainInConstant dom)     = return (fmap Constant dom)
     domainOf (TypedConstant x ty)       = domainOf (Typed (Constant x) ty)
-    domainOf ConstantUndefined{}        = fail "DomainOf-ConstantUndefined"
-    domainOf ConstantFromJSON{}         = fail "DomainOf-ConstantFromJSON"
+    domainOf ConstantUndefined{}        = failDoc "DomainOf-ConstantUndefined"
+    domainOf ConstantFromJSON{}         = failDoc "DomainOf-ConstantFromJSON"
 
     indexDomainsOf ConstantBool{}       = return []
     indexDomainsOf ConstantInt{}        = return []
@@ -286,7 +291,7 @@ instance DomainOf (AbstractLiteral Expression) where
     domainOf (AbsLitRecord       xs) = DomainRecord <$> sequence [ do t <- domainOf x ; return (n,t)
                                                                  | (n,x) <- xs ]
 
-    domainOf (AbsLitVariant Nothing  _ _) = fail "Cannot calculate the domain of variant literal."
+    domainOf (AbsLitVariant Nothing  _ _) = failDoc "Cannot calculate the domain of variant literal."
     domainOf (AbsLitVariant (Just t) _ _) = return (DomainVariant t)
 
     domainOf (AbsLitMatrix ind inn ) = DomainMatrix ind <$> (domainUnions =<< mapM domainOf inn)
@@ -367,7 +372,7 @@ instance DomainOf x => DomainOf (OpDefined x) where
         fDom <- domainOf f
         case fDom of
             DomainFunction _ _ fr _ -> return $ DomainSet def def fr
-            _ -> fail "domainOf, OpDefined, not a function"
+            _ -> failDoc "domainOf, OpDefined, not a function"
 
 instance DomainOf x => DomainOf (OpDiv x) where
     domainOf (OpDiv x y) = do
@@ -423,7 +428,7 @@ instance (Pretty x, TypeOf x, DomainOf x) => DomainOf (OpImage x) where
         case fDomain of
             DomainFunction _ _ _ to -> return to
             DomainSequence _ _ to -> return to
-            _ -> fail "domainOf, OpImage, not a function or sequence"
+            _ -> failDoc "domainOf, OpImage, not a function or sequence"
 
 instance (Pretty x, TypeOf x) => DomainOf (OpImageSet x) where
     domainOf op = mkDomainAny ("OpImageSet:" <++> pretty op) <$> typeOf op
@@ -440,24 +445,24 @@ instance (Pretty x, TypeOf x, ExpressionLike x, DomainOf x) => DomainOf (OpIndex
         case iType of
             TypeBool{} -> return ()
             TypeInt{} -> return ()
-            _ -> fail "domainOf, OpIndexing, not a bool or int index"
+            _ -> failDoc "domainOf, OpIndexing, not a bool or int index"
         mDom <- domainOf m
         case mDom of
             DomainMatrix _ inner -> return inner
             DomainTuple inners -> do
                 iInt <- intOut "domainOf OpIndexing" i
                 return $ atNote "domainOf" inners (fromInteger (iInt-1))
-            _ -> fail "domainOf, OpIndexing, not a matrix or tuple"
+            _ -> failDoc "domainOf, OpIndexing, not a matrix or tuple"
 
     indexDomainsOf p@(OpIndexing m i) = do
         iType <- typeOf i
         case iType of
             TypeBool{} -> return ()
             TypeInt{} -> return ()
-            _ -> fail "domainOf, OpIndexing, not a bool or int index"
+            _ -> failDoc "domainOf, OpIndexing, not a bool or int index"
         is <- indexDomainsOf m
         case is of
-            [] -> fail ("indexDomainsOf{OpIndexing}, not a matrix domain:" <++> pretty p)
+            [] -> failDoc ("indexDomainsOf{OpIndexing}, not a matrix domain:" <++> pretty p)
             (_:is') -> return is'
 
 instance (Pretty x, TypeOf x) => DomainOf (OpIntersect x) where
@@ -548,7 +553,7 @@ instance DomainOf x => DomainOf (OpParts x) where
         dom <- domainOf p
         case dom of
             DomainPartition _ _ inner -> return $ DomainSet def def $ DomainSet def def inner
-            _ -> fail "domainOf, OpParts, not a partition"
+            _ -> failDoc "domainOf, OpParts, not a partition"
 
 instance (Pretty x, TypeOf x) => DomainOf (OpParty x) where
     domainOf op = mkDomainAny ("OpParty:" <++> pretty op) <$> typeOf op
@@ -586,7 +591,7 @@ instance DomainOf x => DomainOf (OpRange x) where
         fDom <- domainOf f
         case fDom of
             DomainFunction _ _ _ to -> return $ DomainSet def def to
-            _ -> fail "domainOf, OpRange, not a function"
+            _ -> failDoc "domainOf, OpRange, not a function"
 
 instance (Pretty x, TypeOf x) => DomainOf (OpRelationProj x) where
     domainOf op = mkDomainAny ("OpRelationProj:" <++> pretty op) <$> typeOf op
@@ -597,14 +602,14 @@ instance (DomainOf x, Dom :< x) => DomainOf (OpRestrict x) where
         fDom <- domainOf f
         case fDom of
             DomainFunction fRepr a _ to -> return (DomainFunction fRepr a d to)
-            _ -> fail "domainOf, OpRestrict, not a function"
+            _ -> failDoc "domainOf, OpRestrict, not a function"
 
 instance (Pretty x, DomainOf x) => DomainOf (OpSlicing x) where
     domainOf (OpSlicing x _ _) = domainOf x
     indexDomainsOf (OpSlicing x _ _) = indexDomainsOf x
 
 instance DomainOf (OpSubsequence x) where
-    domainOf _ = fail "domainOf{OpSubsequence}"
+    domainOf _ = failDoc "domainOf{OpSubsequence}"
 
 instance (Pretty x, TypeOf x) => DomainOf (OpSubset x) where
     domainOf op = mkDomainAny ("OpSubset:" <++> pretty op) <$> typeOf op
@@ -613,7 +618,7 @@ instance (Pretty x, TypeOf x) => DomainOf (OpSubsetEq x) where
     domainOf op = mkDomainAny ("OpSubsetEq:" <++> pretty op) <$> typeOf op
 
 instance DomainOf (OpSubstring x) where
-    domainOf _ = fail "domainOf{OpSubstring}"
+    domainOf _ = failDoc "domainOf{OpSubstring}"
 
 instance DomainOf x => DomainOf (OpSucc x) where
     domainOf (OpSucc x) = domainOf x        -- TODO: improve

--- a/src/Conjure/Compute/DomainOf.hs
+++ b/src/Conjure/Compute/DomainOf.hs
@@ -11,7 +11,6 @@ import Conjure.Language
 import Conjure.Language.Domain ( HasRepresentation(..) )
 import Conjure.Language.RepresentationOf ( RepresentationOf(..) )
 import Conjure.Compute.DomainUnion
-import Conjure.Language.Expression.Op.Internal.Common (getIntTag)
 
 
 type Dom = Domain () Expression

--- a/src/Conjure/Compute/DomainOf.hs
+++ b/src/Conjure/Compute/DomainOf.hs
@@ -20,7 +20,6 @@ class DomainOf a where
 
     -- | calculate the domain of `a`
     domainOf ::
-        MonadFail m =>
         MonadFailDoc m =>
         NameGen m =>
         (?typeCheckerMode :: TypeCheckerMode) =>
@@ -32,7 +31,6 @@ class DomainOf a where
     --   has a default implementation in terms of domainOf, so doesn't need to be implemented specifically.
     --   but sometimes it is better to implement this directly.
     indexDomainsOf ::
-        MonadFail m =>
         MonadFailDoc m =>
         NameGen m =>
         Pretty a =>
@@ -44,7 +42,6 @@ class DomainOf a where
 domainOfR ::
     DomainOf a =>
     RepresentationOf a =>
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -56,7 +53,6 @@ domainOfR inp = do
 
 
 defIndexDomainsOf ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     DomainOf a =>

--- a/src/Conjure/Language/AbstractLiteral.hs
+++ b/src/Conjure/Language/AbstractLiteral.hs
@@ -156,7 +156,7 @@ instance (TypeOf a, Pretty a) => TypeOf (AbstractLiteral a) where
     typeOf   (AbsLitRecord       xs) = TypeRecord   <$> sequence [ do t <- typeOf x ; return (n,t)
                                                                  | (n,x) <- xs ]
 
-    typeOf   (AbsLitVariant Nothing  _ _) = fail "Cannot calculate the type of variant literal."
+    typeOf   (AbsLitVariant Nothing  _ _) = failDoc "Cannot calculate the type of variant literal."
     typeOf   (AbsLitVariant (Just t) _ _) = fmap TypeVariant $ forM t $ \ (n,d) -> do
         dt <- typeOfDomain d
         return (n, dt)

--- a/src/Conjure/Language/AdHoc.hs
+++ b/src/Conjure/Language/AdHoc.hs
@@ -33,7 +33,7 @@ class ReferenceContainer a where
 
 class DomainContainer a dom where
     fromDomain :: dom a -> a
-    domainOut :: MonadFail m => a -> m (dom a)
+    domainOut :: MonadFailDoc m => a -> m (dom a)
 
 class CanBeAnAlias a where
     isAlias :: a -> Maybe a

--- a/src/Conjure/Language/AdHoc.hs
+++ b/src/Conjure/Language/AdHoc.hs
@@ -19,17 +19,17 @@ import Data.Scientific ( floatingOrInteger )
 class ExpressionLike a where
     fromInt :: Integer -> a
     fromIntWithTag :: Integer -> IntTag -> a
-    intOut :: MonadFail m => Doc -> a -> m Integer
+    intOut :: MonadFailDoc m => Doc -> a -> m Integer
 
     fromBool :: Bool -> a
-    boolOut :: MonadFail m => a -> m Bool
+    boolOut :: MonadFailDoc m => a -> m Bool
 
     fromList :: [a] -> a
-    listOut :: MonadFail m => a -> m [a]
+    listOut :: MonadFailDoc m => a -> m [a]
 
 class ReferenceContainer a where
     fromName :: Name -> a
-    nameOut :: MonadFail m => a -> m Name
+    nameOut :: MonadFailDoc m => a -> m Name
 
 class DomainContainer a dom where
     fromDomain :: dom a -> a
@@ -43,7 +43,7 @@ class VarSymBreakingDescription a where
 
 class (:<) a b where
     inject :: a -> b
-    project :: MonadFail m => b -> m a
+    project :: MonadFailDoc m => b -> m a
 
 data MiniZincData = MZNBool Bool
                   | MZNInt Integer

--- a/src/Conjure/Language/Arbitrary.hs
+++ b/src/Conjure/Language/Arbitrary.hs
@@ -200,7 +200,7 @@ arbitraryDomainAndConstant = sized dispatch
             return ( domainOut
                    , let try n =
                             if n >= maxRetries
-                                then fail (vcat [ "setFixed: maxRetries"
+                                then failDoc (vcat [ "setFixed: maxRetries"
                                                 , pretty domainOut
                                                 ])
                                 else do
@@ -251,7 +251,7 @@ arbitraryDomainAndConstant = sized dispatch
             return ( domainOut
                    , let try n =
                             if n >= maxRetries
-                                then fail (vcat [ "setFixed: maxRetries"
+                                then failDoc (vcat [ "setFixed: maxRetries"
                                                 , pretty domainOut
                                                 ])
                                 else do
@@ -265,7 +265,7 @@ arbitraryDomainAndConstant = sized dispatch
                    )
 
 pickFromList :: [a] -> Gen a
-pickFromList [] = fail "pickFromList []"
+pickFromList [] = failDoc "pickFromList []"
 pickFromList xs = do
     index <- choose (0, length xs - 1)
     return (xs `at` index)

--- a/src/Conjure/Language/CategoryOf.hs
+++ b/src/Conjure/Language/CategoryOf.hs
@@ -58,7 +58,7 @@ instance CategoryOf FindOrGiven where
 
 -- | Category checking to check if domains have anything >CatParameter in them.
 --   Run only after name resolution.
-categoryChecking :: (MonadFail m, MonadUserError m) => Model -> m Model
+categoryChecking :: (MonadFailDoc m, MonadUserError m) => Model -> m Model
 categoryChecking m = do
     errors1 <- fmap concat $ forM (mStatements m) $ \ st -> case st of
         Declaration (FindOrGiven _forg name domain) -> do

--- a/src/Conjure/Language/Constant.hs
+++ b/src/Conjure/Language/Constant.hs
@@ -252,7 +252,7 @@ instance ReferenceContainer Constant where
 instance DomainContainer Constant (Domain ()) where
     fromDomain = DomainInConstant
     domainOut (DomainInConstant dom) = return dom
-    domainOut _ = fail  "domainOut{Constant}"
+    domainOut _ = failDoc  "domainOut{Constant}"
 
 mkUndef :: Type -> Doc -> Constant
 mkUndef TypeBool _ = ConstantBool False

--- a/src/Conjure/Language/Domain/AddAttributes.hs
+++ b/src/Conjure/Language/Domain/AddAttributes.hs
@@ -50,7 +50,7 @@ allSupportedAttributes =
 
 
 addAttributesToDomain
-    :: ( MonadFail m
+    :: ( MonadFailDoc m
        , Pretty r
        )
     => Domain r Expression
@@ -63,7 +63,7 @@ addAttributesToDomain domain ((attr, val) : rest) = do
 
 
 addAttributeToDomain
-    :: ( MonadFail m
+    :: ( MonadFailDoc m
        , Pretty r
        )
     => Domain r Expression                          -- the input domain
@@ -90,10 +90,10 @@ addAttributeToDomain domain@(DomainSet r (SetAttr sizeAttr) inner) = updater whe
         AttrName_size ->
             case sizeAttr of
                 SizeAttr_Size s | val == s -> return domain
-                SizeAttr_Size{}            -> fail $ "Cannot add a size attribute to this domain:" <++> pretty domain
+                SizeAttr_Size{}            -> failDoc $ "Cannot add a size attribute to this domain:" <++> pretty domain
                 _                          -> return $ DomainSet r (SetAttr (SizeAttr_Size val)) inner
         AttrName_minSize -> do
-            let fails = fail $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
+            let fails = failDoc $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
                 SizeAttr_Size s | val == s    -> return domain
                 SizeAttr_Size{}               -> fails
@@ -104,7 +104,7 @@ addAttributeToDomain domain@(DomainSet r (SetAttr sizeAttr) inner) = updater whe
                 SizeAttr_MinMaxSize minS maxS -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize (mkMax minS val) maxS)) inner
                 SizeAttr_None{}               -> return $ DomainSet r (SetAttr (SizeAttr_MinSize val)) inner
         AttrName_maxSize -> do
-            let fails = fail $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
+            let fails = failDoc $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
                 SizeAttr_Size s | val == s    -> return domain
                 SizeAttr_Size{}               -> fails
@@ -115,11 +115,11 @@ addAttributeToDomain domain@(DomainSet r (SetAttr sizeAttr) inner) = updater whe
                 SizeAttr_MinMaxSize minS maxS -> return $ DomainSet r (SetAttr (SizeAttr_MinMaxSize minS (mkMin maxS val))) inner
                 SizeAttr_None{}               -> return $ DomainSet r (SetAttr (SizeAttr_MaxSize val)) inner
         _ ->
-            fail $ vcat [ "Unsupported attribute" <+> pretty attr
+            failDoc $ vcat [ "Unsupported attribute" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
     updater attr Nothing =
-            fail $ vcat [ "Missing attribute value for" <+> pretty attr
+            failDoc $ vcat [ "Missing attribute value for" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
 
@@ -128,10 +128,10 @@ addAttributeToDomain domain@(DomainMSet r (MSetAttr sizeAttr occurAttr) inner) =
         AttrName_size ->
             case sizeAttr of
                 SizeAttr_Size s | val == s -> return domain
-                SizeAttr_Size{}            -> fail $ "Cannot add a size attribute to this domain:" <++> pretty domain
+                SizeAttr_Size{}            -> failDoc $ "Cannot add a size attribute to this domain:" <++> pretty domain
                 _                          -> return $ DomainMSet r (MSetAttr (SizeAttr_Size val) occurAttr) inner
         AttrName_minSize -> do
-            let fails = fail $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
+            let fails = failDoc $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
                 SizeAttr_Size s | val == s    -> return domain
                 SizeAttr_Size{}               -> fails
@@ -154,7 +154,7 @@ addAttributeToDomain domain@(DomainMSet r (MSetAttr sizeAttr occurAttr) inner) =
                                                  (MSetAttr (SizeAttr_MinSize val)                      occurAttr)
                                                  inner
         AttrName_maxSize -> do
-            let fails = fail $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
+            let fails = failDoc $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
                 SizeAttr_Size s | val == s    -> return domain
                 SizeAttr_Size{}               -> fails
@@ -205,11 +205,11 @@ addAttributeToDomain domain@(DomainMSet r (MSetAttr sizeAttr occurAttr) inner) =
                                                    (MSetAttr sizeAttr (OccurAttr_MaxOccur val))
                                                    inner
         _ ->
-            fail $ vcat [ "Unsupported attribute" <+> pretty attr
+            failDoc $ vcat [ "Unsupported attribute" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
     updater attr Nothing =
-            fail $ vcat [ "Missing attribute value for" <+> pretty attr
+            failDoc $ vcat [ "Missing attribute value for" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
 
@@ -219,12 +219,12 @@ addAttributeToDomain domain@(DomainFunction r
     updater attr (Just val) = case attr of
         AttrName_size ->
             case sizeAttr of
-                SizeAttr_Size{} -> fail $ "Cannot add a size attribute to this domain:" <++> pretty domain
+                SizeAttr_Size{} -> failDoc $ "Cannot add a size attribute to this domain:" <++> pretty domain
                 _               -> return $ DomainFunction r
                                             (FunctionAttr (SizeAttr_Size val) partialityAttr jectivityAttr)
                                             inF inT
         AttrName_minSize -> do
-            let fails = fail $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
+            let fails = failDoc $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
                 SizeAttr_Size{}       -> fails
                 SizeAttr_MinSize{}    -> fails
@@ -236,7 +236,7 @@ addAttributeToDomain domain@(DomainFunction r
                                             (FunctionAttr (SizeAttr_MinMaxSize val maxS) partialityAttr jectivityAttr)
                                             inF inT
         AttrName_maxSize -> do
-            let fails = fail $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
+            let fails = failDoc $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
                 SizeAttr_Size{}       -> fails
                 SizeAttr_MaxSize{}    -> fails
@@ -248,7 +248,7 @@ addAttributeToDomain domain@(DomainFunction r
                                             (FunctionAttr (SizeAttr_MinMaxSize minS val) partialityAttr jectivityAttr)
                                             inF inT
         _ ->
-            fail $ vcat [ "Unsupported attribute" <+> pretty attr
+            failDoc $ vcat [ "Unsupported attribute" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
     updater "total" Nothing = return $ DomainFunction r
@@ -286,7 +286,7 @@ addAttributeToDomain domain@(DomainFunction r
                                             (FunctionAttr sizeAttr partialityAttr JectivityAttr_Bijective)
                                             inF inT
     updater attr _ =
-        fail $ vcat [ "Unsupported attribute" <+> pretty attr
+        failDoc $ vcat [ "Unsupported attribute" <+> pretty attr
                     , "For the domain:" <+> pretty domain
                     ]
 
@@ -296,12 +296,12 @@ addAttributeToDomain domain@(DomainSequence r
     updater attr (Just val) = case attr of
         AttrName_size ->
             case sizeAttr of
-                SizeAttr_Size{} -> fail $ "Cannot add a size attribute to this domain:" <++> pretty domain
+                SizeAttr_Size{} -> failDoc $ "Cannot add a size attribute to this domain:" <++> pretty domain
                 _               -> return $ DomainSequence r
                                             (SequenceAttr (SizeAttr_Size val) jectivityAttr)
                                             inner
         AttrName_minSize -> do
-            let fails = fail $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
+            let fails = failDoc $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
                 SizeAttr_Size{}       -> fails
                 SizeAttr_MinSize{}    -> fails
@@ -313,7 +313,7 @@ addAttributeToDomain domain@(DomainSequence r
                                             (SequenceAttr (SizeAttr_MinMaxSize val maxS) jectivityAttr)
                                             inner
         AttrName_maxSize -> do
-            let fails = fail $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
+            let fails = failDoc $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
                 SizeAttr_Size{}       -> fails
                 SizeAttr_MaxSize{}    -> fails
@@ -325,7 +325,7 @@ addAttributeToDomain domain@(DomainSequence r
                                             (SequenceAttr (SizeAttr_MinMaxSize minS val) jectivityAttr)
                                             inner
         _ ->
-            fail $ vcat [ "Unsupported attribute" <+> pretty attr
+            failDoc $ vcat [ "Unsupported attribute" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
     updater "injective" Nothing = return $
@@ -360,7 +360,7 @@ addAttributeToDomain domain@(DomainSequence r
                                             (SequenceAttr sizeAttr JectivityAttr_Bijective)
                                             inner
     updater attr _ =
-        fail $ vcat [ "Unsupported attribute" <+> pretty attr
+        failDoc $ vcat [ "Unsupported attribute" <+> pretty attr
                     , "For the domain:" <+> pretty domain
                     ]
 
@@ -377,10 +377,10 @@ addAttributeToDomain domain@(DomainRelation r
     updater attr (Just val) = case attr of
         AttrName_size ->
             case sizeAttr of
-                SizeAttr_Size{} -> fail $ "Cannot add a size attribute to this domain:" <++> pretty domain
+                SizeAttr_Size{} -> failDoc $ "Cannot add a size attribute to this domain:" <++> pretty domain
                 _               -> return $ DomainRelation r (RelationAttr (SizeAttr_Size val) binRelAttr) inners
         AttrName_minSize -> do
-            let fails = fail $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
+            let fails = failDoc $ "Cannot add a minSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
                 SizeAttr_Size{}       -> fails
                 SizeAttr_MinSize{}    -> fails
@@ -392,7 +392,7 @@ addAttributeToDomain domain@(DomainRelation r
                                             (RelationAttr (SizeAttr_MinMaxSize val maxS) binRelAttr)
                                             inners
         AttrName_maxSize -> do
-            let fails = fail $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
+            let fails = failDoc $ "Cannot add a maxSize attribute to this domain:" <++> pretty domain
             case sizeAttr of
                 SizeAttr_Size{}       -> fails
                 SizeAttr_MaxSize{}    -> fails
@@ -404,19 +404,19 @@ addAttributeToDomain domain@(DomainRelation r
                                             (RelationAttr (SizeAttr_MinMaxSize minS val) binRelAttr)
                                             inners
         _ ->
-            fail $ vcat [ "Unsupported attribute" <+> pretty attr
+            failDoc $ vcat [ "Unsupported attribute" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
     updater attr Nothing | attr `elem` supportedBinRel = case readBinRel attr of
         Nothing ->
-            fail $ vcat [ "Unsupported attribute" <+> pretty attr
+            failDoc $ vcat [ "Unsupported attribute" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
         Just a  -> return $ DomainRelation r
                                 (RelationAttr sizeAttr (binRelAttr `mappend` BinaryRelationAttrs (S.singleton a)))
                                 inners
     updater attr _ =
-            fail $ vcat [ "Unsupported attribute" <+> pretty attr
+            failDoc $ vcat [ "Unsupported attribute" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
 
@@ -426,10 +426,10 @@ addAttributeToDomain domain@(DomainPartition r partitionAttr inner) = updater wh
         AttrName_numParts ->
             case partsNum partitionAttr of
                 SizeAttr_Size s | val == s -> return domain
-                SizeAttr_Size{}            -> fail $ "Cannot add a numParts attribute to this domain:" <++> pretty domain
+                SizeAttr_Size{}            -> failDoc $ "Cannot add a numParts attribute to this domain:" <++> pretty domain
                 _                          -> return $ DomainPartition r (partitionAttr { partsNum = SizeAttr_Size val }) inner
         AttrName_minNumParts -> do
-            let fails = fail $ "Cannot add a minNumParts attribute to this domain:" <++> pretty domain
+            let fails = failDoc $ "Cannot add a minNumParts attribute to this domain:" <++> pretty domain
             case partsNum partitionAttr of
                 SizeAttr_Size s | val == s    -> return domain
                 SizeAttr_Size{}               -> fails
@@ -452,7 +452,7 @@ addAttributeToDomain domain@(DomainPartition r partitionAttr inner) = updater wh
                                                  partitionAttr { partsNum = SizeAttr_MinSize val }
                                                  inner
         AttrName_maxNumParts -> do
-            let fails = fail $ "Cannot add a maxNumParts attribute to this domain:" <++> pretty domain
+            let fails = failDoc $ "Cannot add a maxNumParts attribute to this domain:" <++> pretty domain
             case partsNum partitionAttr of
                 SizeAttr_Size s | val == s    -> return domain
                 SizeAttr_Size{}               -> fails
@@ -478,10 +478,10 @@ addAttributeToDomain domain@(DomainPartition r partitionAttr inner) = updater wh
         AttrName_partSize ->
             case partsSize partitionAttr of
                 SizeAttr_Size s | val == s -> return domain
-                SizeAttr_Size{} -> fail $ "Cannot add a partSize attribute to this domain:" <++> pretty domain
+                SizeAttr_Size{} -> failDoc $ "Cannot add a partSize attribute to this domain:" <++> pretty domain
                 _               -> return $ DomainPartition r (partitionAttr { partsSize = SizeAttr_Size val }) inner
         AttrName_minPartSize -> do
-            let fails = fail $ "Cannot add a minPartSize attribute to this domain:" <++> pretty domain
+            let fails = failDoc $ "Cannot add a minPartSize attribute to this domain:" <++> pretty domain
             case partsSize partitionAttr of
                 SizeAttr_Size s | val == s    -> return domain
                 SizeAttr_Size{}               -> fails
@@ -504,7 +504,7 @@ addAttributeToDomain domain@(DomainPartition r partitionAttr inner) = updater wh
                                                  (partitionAttr { partsSize = SizeAttr_MinSize val })
                                                  inner
         AttrName_maxPartSize -> do
-            let fails = fail $ "Cannot add a maxPartSize attribute to this domain:" <++> pretty domain
+            let fails = failDoc $ "Cannot add a maxPartSize attribute to this domain:" <++> pretty domain
             case partsSize partitionAttr of
                 SizeAttr_Size s | val == s    -> return domain
                 SizeAttr_Size{}               -> fails
@@ -528,13 +528,13 @@ addAttributeToDomain domain@(DomainPartition r partitionAttr inner) = updater wh
                                                  inner
 
         _ ->
-            fail $ vcat [ "Unsupported attribute" <+> pretty attr
+            failDoc $ vcat [ "Unsupported attribute" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
     updater AttrName_regular Nothing =
             return $ DomainPartition r (partitionAttr { isRegular  = True }) inner
     updater attr Nothing =
-            fail $ vcat [ "Missing attribute value for" <+> pretty attr
+            failDoc $ vcat [ "Missing attribute value for" <+> pretty attr
                         , "For the domain:" <+> pretty domain
                         ]
 

--- a/src/Conjure/Language/DomainSizeOf.hs
+++ b/src/Conjure/Language/DomainSizeOf.hs
@@ -13,7 +13,7 @@ import Conjure.Language.Pretty
 
 class DomainSizeOf x res where
     domainSizeOf ::
-        ( MonadFail m
+        ( MonadFailDoc m
         , Pretty r
         , Default r
         ) => Domain r x -> m res

--- a/src/Conjure/Language/EvaluateOp.hs
+++ b/src/Conjure/Language/EvaluateOp.hs
@@ -16,7 +16,6 @@ import {-# SOURCE #-} Conjure.Process.ValidateConstantForDomain ( validateConsta
 class EvaluateOp op where
     evaluateOp :: 
         MonadFailDoc m =>
-        MonadFail m =>
         NameGen m =>
         EnumerateDomain m =>
         (?typeCheckerMode :: TypeCheckerMode) =>

--- a/src/Conjure/Language/EvaluateOp.hs
+++ b/src/Conjure/Language/EvaluateOp.hs
@@ -15,6 +15,7 @@ import {-# SOURCE #-} Conjure.Process.ValidateConstantForDomain ( validateConsta
 --   Make sure the output is normalised.
 class EvaluateOp op where
     evaluateOp :: 
+        MonadFailDoc m =>
         MonadFail m =>
         NameGen m =>
         EnumerateDomain m =>
@@ -111,7 +112,7 @@ instance EvaluateOp OpFlatten where
     evaluateOp (OpFlatten (Just n) m) = do
         let flat lvl c | lvl < 0 = return [c]
             flat lvl (viewConstantMatrix -> Just (_, xs)) = concatMapM (flat (lvl-1)) xs
-            flat _ _ = fail $ "Cannot flatten" <+> pretty n <+> "levels."
+            flat _ _ = failDoc $ "Cannot flatten" <+> pretty n <+> "levels."
         flattened <- flat n m
         return (ConstantAbstract $ AbsLitMatrix
                     (DomainInt TagInt [RangeBounded 1 (fromInt (genericLength flattened))])
@@ -204,7 +205,7 @@ instance EvaluateOp OpIndexing where
         ty   <- typeOf m
         tyTo <- case ty of TypeMatrix _ tyTo -> return tyTo
                            TypeList tyTo     -> return tyTo
-                           _ -> fail "evaluateOp{OpIndexing}"
+                           _ -> failDoc "evaluateOp{OpIndexing}"
         return $ mkUndef tyTo $ "Has undefined children (index):" <+> pretty p
     evaluateOp (OpIndexing m@(viewConstantMatrix -> Just (DomainInt _ index, vals)) (ConstantInt _ x)) = do
             ty   <- typeOf m
@@ -226,7 +227,7 @@ instance EvaluateOp OpIndexing where
         return (at vals (fromInteger (x-1)))
     evaluateOp rec@(OpIndexing (viewConstantRecord -> Just vals) (ConstantField name _)) =
         case lookup name vals of
-            Nothing -> fail $ vcat
+            Nothing -> failDoc $ vcat
                     [ "Record doesn't have a member with this name:" <+> pretty name
                     , "Record:" <+> pretty rec
                     ]
@@ -799,21 +800,21 @@ instance EvaluateOp OpXor where
         where xor xs = 1 == length [ () | True <- xs ]
 
 
-boolsOut :: MonadFail m => Constant -> m [Bool]
+boolsOut :: MonadFailDoc m => Constant -> m [Bool]
 boolsOut (viewConstantMatrix -> Just (_, cs)) = concatMapM boolsOut cs
 boolsOut b = return <$> boolOut b
 
-intsOut :: MonadFail m => Doc -> Constant -> m [Integer]
+intsOut :: MonadFailDoc m => Doc -> Constant -> m [Integer]
 intsOut doc (viewConstantMatrix -> Just (_, cs)) = concatMapM (intsOut doc) cs
 intsOut doc (viewConstantSet -> Just cs) = concatMapM (intsOut doc) cs
 intsOut doc (viewConstantMSet -> Just cs) = concatMapM (intsOut doc) cs
 intsOut doc b = return <$> intOut ("intsOut" <+> doc) b
 
-intsOut2D :: MonadFail m => Doc -> Constant -> m [[Integer]]
+intsOut2D :: MonadFailDoc m => Doc -> Constant -> m [[Integer]]
 intsOut2D doc (viewConstantMatrix -> Just (_, cs)) = mapM (intsOut doc) cs
 intsOut2D doc (viewConstantSet -> Just cs) = mapM (intsOut doc) cs
 intsOut2D doc (viewConstantMSet -> Just cs) = mapM (intsOut doc) cs
-intsOut2D doc _ = fail ("intsOut2D" <+> doc)
+intsOut2D doc _ = failDoc ("intsOut2D" <+> doc)
 
 tildeLt :: Constant -> Constant -> Bool
 tildeLt = tilLt

--- a/src/Conjure/Language/Expression/Op/Factorial.hs
+++ b/src/Conjure/Language/Expression/Op/Factorial.hs
@@ -20,7 +20,7 @@ instance FromJSON  x => FromJSON  (OpFactorial x) where parseJSON = genericParse
 
 instance (TypeOf x, Pretty x) => TypeOf (OpFactorial x) where
     typeOf p@(OpFactorial a) = do
-        t <- getIntTag a
+        TypeInt t <- typeOf a
         case t of
             TagInt -> return ()
             _ -> raiseTypeError p

--- a/src/Conjure/Language/Expression/Op/Factorial.hs
+++ b/src/Conjure/Language/Expression/Op/Factorial.hs
@@ -20,7 +20,7 @@ instance FromJSON  x => FromJSON  (OpFactorial x) where parseJSON = genericParse
 
 instance (TypeOf x, Pretty x) => TypeOf (OpFactorial x) where
     typeOf p@(OpFactorial a) = do
-        TypeInt t <- typeOf a
+        t <- getIntTag a
         case t of
             TagInt -> return ()
             _ -> raiseTypeError p

--- a/src/Conjure/Language/Expression/Op/Indexing.hs
+++ b/src/Conjure/Language/Expression/Op/Indexing.hs
@@ -28,7 +28,7 @@ instance (TypeOf x, Pretty x, ExpressionLike x, ReferenceContainer x) => TypeOf 
         case tyM of
             TypeMatrix tyIndex inn
                 | typesUnify [tyIndex, tyI] -> return inn
-                | otherwise -> fail $ "Indexing with inappropriate type:" <++> vcat
+                | otherwise -> failDoc $ "Indexing with inappropriate type:" <++> vcat
                     [ "The expression:"  <+> pretty p
                     , "Indexing:"        <+> pretty m
                     , "Expected type of index:" <+> pretty tyIndex
@@ -36,26 +36,26 @@ instance (TypeOf x, Pretty x, ExpressionLike x, ReferenceContainer x) => TypeOf 
                     ]
             TypeList inn
                 | typesUnify [TypeInt TagInt, tyI] -> return inn
-                | otherwise -> fail $ "Indexing with inappropriate type:" <++> vcat
+                | otherwise -> failDoc $ "Indexing with inappropriate type:" <++> vcat
                     [ "The expression:"  <+> pretty p
                     , "Indexing:"        <+> pretty m
                     , "Expected type of index:" <+> pretty (TypeInt TagInt)
                     , "Actual type of index  :" <+> pretty tyI
                     ]
             TypeTuple inns   -> do
-                TypeInt t <- typeOf i
+                t <- typeOf i
                 case t of
-                    TagInt -> return ()
-                    _ -> fail $ "Tuples cannot be indexed by enums/unnameds:" <++> pretty p
+                    TypeInt TagInt -> return ()
+                    _ -> failDoc $ "Tuples cannot be indexed by enums/unnameds:" <++> pretty p
                 case intOut "OpIndexing" i of
-                    Nothing -> fail $ "Tuples can only be indexed by constants:" <++> pretty p
+                    Nothing -> failDoc $ "Tuples can only be indexed by constants:" <++> pretty p
                     Just iInt | iInt <= 0 || iInt > genericLength inns ->
-                                    fail $ "Out of bounds tuple indexing:" <++> pretty p
+                                    failDoc $ "Out of bounds tuple indexing:" <++> pretty p
                               | otherwise -> return (at inns (fromInteger (iInt-1)))
             TypeRecord inns  -> do
                 nm <- nameOut i
                 case lookup nm inns of
-                    Nothing -> fail $ "Record indexing with non-member field:" <++> vcat
+                    Nothing -> failDoc $ "Record indexing with non-member field:" <++> vcat
                         [ "The expression:" <+> pretty p
                         , "Indexing:"       <+> pretty m
                         , "With type:"      <+> pretty tyM
@@ -64,13 +64,13 @@ instance (TypeOf x, Pretty x, ExpressionLike x, ReferenceContainer x) => TypeOf 
             TypeVariant inns -> do
                 nm <- nameOut i
                 case lookup nm inns of
-                    Nothing -> fail $ "Variant indexing with non-member field:" <++> vcat
+                    Nothing -> failDoc $ "Variant indexing with non-member field:" <++> vcat
                         [ "The expression:" <+> pretty p
                         , "Indexing:"       <+> pretty m
                         , "With type:"      <+> pretty tyM
                         ]
                     Just ty -> return ty
-            _ -> fail $ "Indexing something other than a matrix or a tuple:" <++> vcat
+            _ -> failDoc $ "Indexing something other than a matrix or a tuple:" <++> vcat
                     [ "The expression:" <+> pretty p
                     , "Indexing:"       <+> pretty m
                     , "With type:"      <+> pretty tyM

--- a/src/Conjure/Language/Expression/Op/Indexing.hs
+++ b/src/Conjure/Language/Expression/Op/Indexing.hs
@@ -43,9 +43,9 @@ instance (TypeOf x, Pretty x, ExpressionLike x, ReferenceContainer x) => TypeOf 
                     , "Actual type of index  :" <+> pretty tyI
                     ]
             TypeTuple inns   -> do
-                t <- typeOf i
+                TypeInt t <- typeOf i
                 case t of
-                    TypeInt TagInt -> return ()
+                    TagInt -> return ()
                     _ -> failDoc $ "Tuples cannot be indexed by enums/unnameds:" <++> pretty p
                 case intOut "OpIndexing" i of
                     Nothing -> failDoc $ "Tuples can only be indexed by constants:" <++> pretty p

--- a/src/Conjure/Language/Expression/Op/Internal/Common.hs
+++ b/src/Conjure/Language/Expression/Op/Internal/Common.hs
@@ -16,8 +16,6 @@ module Conjure.Language.Expression.Op.Internal.Common
     , boolToBoolToBool
     , sameToSameToBool
     , sameToSameToSame
-    , getFunctionTypes
-    , getIntTag
     ) where
 
 -- conjure
@@ -297,20 +295,6 @@ functionals =
     , L_powerSet
 
     ]
-
-getFunctionTypes :: (MonadFailDoc m,TypeOf a,?typeCheckerMode :: TypeCheckerMode) => a -> m (Type , Type)
-getFunctionTypes f = do
-    f' <- typeOf f
-    case f' of
-        TypeFunction a b -> return (a,b)
-        _ -> raiseTypeError f'
-
-getIntTag ::(MonadFailDoc m,TypeOf a,?typeCheckerMode :: TypeCheckerMode) => a -> m IntTag 
-getIntTag i = do
-    i' <- typeOf i
-    case i' of 
-        TypeInt t -> return t
-        _ -> raiseTypeError i'
 
 raiseTypeError :: MonadFailDoc m => Pretty a => a -> m b
 raiseTypeError p = failDoc ("Type error in" <+> pretty p)

--- a/src/Conjure/Language/Expression/Op/Internal/Common.hs
+++ b/src/Conjure/Language/Expression/Op/Internal/Common.hs
@@ -16,7 +16,8 @@ module Conjure.Language.Expression.Op.Internal.Common
     , boolToBoolToBool
     , sameToSameToBool
     , sameToSameToSame
-
+    , getFunctionTypes
+    , getIntTag
     ) where
 
 -- conjure
@@ -35,7 +36,7 @@ import Conjure.Language.Lexer as X ( Lexeme(..), textToLexeme, lexemeFace )
 
 class SimplifyOp op x where
     simplifyOp ::
-        MonadFail m =>
+        MonadFailDoc m =>
         Eq x =>
         Num x =>
         ExpressionLike x =>
@@ -74,18 +75,18 @@ prettyPrecBinOp envPrec op a b =
                                                        , prettyPrec  prec    b
                                                        ]
 
-intToInt :: (MonadFail m, TypeOf a, Pretty p, ?typeCheckerMode :: TypeCheckerMode) => p -> a -> m Type
+intToInt :: (MonadFailDoc m, TypeOf a, Pretty p, ?typeCheckerMode :: TypeCheckerMode) => p -> a -> m Type
 intToInt p a = do
     tya <- typeOf a
     case tya of
         TypeInt t -> return (TypeInt t)
-        _         -> fail $ vcat
+        _         -> failDoc $ vcat
             [ "When type checking:" <+> pretty p
             , "Argument expected to be an int, but it is:" <++> pretty tya
             ]
 
 
-intToIntToInt :: (MonadFail m, TypeOf a, Pretty p, ?typeCheckerMode :: TypeCheckerMode) => p -> a -> a -> m Type
+intToIntToInt :: (MonadFailDoc m, TypeOf a, Pretty p, ?typeCheckerMode :: TypeCheckerMode) => p -> a -> a -> m Type
 intToIntToInt p a b = do
     tya <- typeOf a
     tyb <- typeOf b
@@ -93,31 +94,31 @@ intToIntToInt p a b = do
         (TypeInt{}, TypeInt{}) ->
             if typeUnify tya tyb
                 then return $ mostDefined [tya, tyb]
-                else fail $ vcat
+                else failDoc $ vcat
                         [ "When type checking:" <+> pretty p
                         , "Types do not unify:" <++> pretty tya 
                         ]
-        (_, TypeInt{})         -> fail $ vcat
+        (_, TypeInt{})         -> failDoc $ vcat
             [ "When type checking:" <+> pretty p
             ,  "First argument expected to be an int, but it is:" <++> pretty tya
             ]
-        _                      -> fail $ vcat
+        _                      -> failDoc $ vcat
             [ "When type checking:" <+> pretty p
             , "Second argument expected to be an int, but it is:" <++> pretty tyb
             ]
 
 
-boolToBoolToBool :: (MonadFail m, TypeOf a, Pretty p, ?typeCheckerMode :: TypeCheckerMode) => p -> a -> a -> m Type
+boolToBoolToBool :: (MonadFailDoc m, TypeOf a, Pretty p, ?typeCheckerMode :: TypeCheckerMode) => p -> a -> a -> m Type
 boolToBoolToBool p a b = do
     tya <- typeOf a
     tyb <- typeOf b
     case (tya, tyb) of
         (TypeBool, TypeBool) -> return TypeBool
-        (_, TypeBool)        -> fail $ vcat
+        (_, TypeBool)        -> failDoc $ vcat
             [ "When type checking:" <+> pretty p
             ,  "First argument expected to be a bool, but it is:" <++> pretty tya
             ]
-        _                    -> fail $ vcat
+        _                    -> failDoc $ vcat
             [ "When type checking:" <+> pretty p
             , "Second argument expected to be a bool, but it is:" <++> pretty tyb
             ]
@@ -126,7 +127,7 @@ boolToBoolToBool p a b = do
 -- if acceptableTypes is null, use checkType
 -- if acceptableTypes is not null, either one of these is true or checkType
 sameToSameToBool
-    :: ( MonadFail m, ?typeCheckerMode :: TypeCheckerMode
+    :: ( MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode
        , TypeOf a, Pretty a, Pretty p
        ) => p -> a -> a -> [Type] -> (Type -> Bool) -> m Type
 sameToSameToBool p a b acceptableTypes checkType = do
@@ -138,7 +139,7 @@ sameToSameToBool p a b acceptableTypes checkType = do
                     else checkType tyAB || any (typeUnify tyAB) acceptableTypes
     case (tyA `typeUnify` tyB, allowed) of
         (True, True) -> return TypeBool
-        (False, _) -> fail $ vcat
+        (False, _) -> failDoc $ vcat
             [ "When type checking:" <+> pretty p
             , "Cannot unify the types of the following."
             , "lhs        :" <+> pretty a
@@ -146,7 +147,7 @@ sameToSameToBool p a b acceptableTypes checkType = do
             , "rhs        :" <+> pretty b
             , "type of rhs:" <+> pretty tyB
             ]
-        (_, False) -> fail $ vcat
+        (_, False) -> failDoc $ vcat
             [ "When type checking:" <+> pretty p
             , "Arguments have unsupported types."
             , "lhs        :" <+> pretty a
@@ -157,7 +158,7 @@ sameToSameToBool p a b acceptableTypes checkType = do
 
 -- See sameToSameToBool
 sameToSameToSame
-    :: ( MonadFail m
+    :: ( MonadFailDoc m
        , ?typeCheckerMode :: TypeCheckerMode
        , TypeOf a, Pretty a, Pretty p
        ) => p -> a -> a -> [Type] -> (Type -> Bool) -> m Type
@@ -170,7 +171,7 @@ sameToSameToSame p a b acceptableTypes checkType = do
                     else checkType tyAB || any (typeUnify tyAB) acceptableTypes
     case (tyA `typeUnify` tyB, allowed) of
         (True, True) -> return tyAB
-        (False, _) -> fail $ vcat
+        (False, _) -> failDoc $ vcat
             [ "When type checking:" <+> pretty p
             , "Cannot unify the types of the following."
             , "lhs        :" <+> pretty a
@@ -178,7 +179,7 @@ sameToSameToSame p a b acceptableTypes checkType = do
             , "rhs        :" <+> pretty b
             , "type of rhs:" <+> pretty tyB
             ]
-        (_, False) -> fail $ vcat
+        (_, False) -> failDoc $ vcat
             [ "When type checking:" <+> pretty p
             , "Arguments have unsupported types."
             , "lhs        :" <+> pretty a
@@ -297,5 +298,19 @@ functionals =
 
     ]
 
-raiseTypeError :: MonadFail m => Pretty a => a -> m b
-raiseTypeError p = fail ("Type error in" <+> pretty p)
+getFunctionTypes :: (MonadFailDoc m,TypeOf a,?typeCheckerMode :: TypeCheckerMode) => a -> m (Type , Type)
+getFunctionTypes f = do
+    f' <- typeOf f
+    case f' of
+        TypeFunction a b -> return (a,b)
+        _ -> raiseTypeError f'
+
+getIntTag ::(MonadFailDoc m,TypeOf a,?typeCheckerMode :: TypeCheckerMode) => a -> m IntTag 
+getIntTag i = do
+    i' <- typeOf i
+    case i' of 
+        TypeInt t -> return t
+        _ -> raiseTypeError i'
+
+raiseTypeError :: MonadFailDoc m => Pretty a => a -> m b
+raiseTypeError p = failDoc ("Type error in" <+> pretty p)

--- a/src/Conjure/Language/Expression/Op/Inverse.hs
+++ b/src/Conjure/Language/Expression/Op/Inverse.hs
@@ -20,8 +20,8 @@ instance FromJSON  x => FromJSON  (OpInverse x) where parseJSON = genericParseJS
 
 instance (TypeOf x, Pretty x) => TypeOf (OpInverse x) where
     typeOf p@(OpInverse f g) = do
-        TypeFunction fFrom fTo <- typeOf f
-        TypeFunction gFrom gTo <- typeOf g
+        (fFrom, fTo) <- getFunctionTypes f
+        (gFrom, gTo) <- getFunctionTypes g
         if typesUnify [fFrom, gTo] && typesUnify [fTo, gFrom]
             then return TypeBool
             else raiseTypeError p

--- a/src/Conjure/Language/Expression/Op/Inverse.hs
+++ b/src/Conjure/Language/Expression/Op/Inverse.hs
@@ -20,8 +20,8 @@ instance FromJSON  x => FromJSON  (OpInverse x) where parseJSON = genericParseJS
 
 instance (TypeOf x, Pretty x) => TypeOf (OpInverse x) where
     typeOf p@(OpInverse f g) = do
-        (fFrom, fTo) <- getFunctionTypes f
-        (gFrom, gTo) <- getFunctionTypes g
+        TypeFunction fFrom fTo <- typeOf f
+        TypeFunction gFrom gTo <- typeOf g
         if typesUnify [fFrom, gTo] && typesUnify [fTo, gFrom]
             then return TypeBool
             else raiseTypeError p

--- a/src/Conjure/Language/Expression/Op/Negate.hs
+++ b/src/Conjure/Language/Expression/Op/Negate.hs
@@ -20,7 +20,7 @@ instance FromJSON  x => FromJSON  (OpNegate x) where parseJSON = genericParseJSO
 
 instance (TypeOf x, Pretty x) => TypeOf (OpNegate x) where
     typeOf p@(OpNegate a) = do
-        t <- getIntTag a
+        TypeInt t <- typeOf a
         case t of
             TagInt -> return ()
             _ -> raiseTypeError p

--- a/src/Conjure/Language/Expression/Op/Negate.hs
+++ b/src/Conjure/Language/Expression/Op/Negate.hs
@@ -20,7 +20,7 @@ instance FromJSON  x => FromJSON  (OpNegate x) where parseJSON = genericParseJSO
 
 instance (TypeOf x, Pretty x) => TypeOf (OpNegate x) where
     typeOf p@(OpNegate a) = do
-        TypeInt t <- typeOf a
+        t <- getIntTag a
         case t of
             TagInt -> return ()
             _ -> raiseTypeError p

--- a/src/Conjure/Language/Expression/Op/Restrict.hs
+++ b/src/Conjure/Language/Expression/Op/Restrict.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric, DeriveDataTypeable, DeriveFunctor, DeriveTraversable, DeriveFoldable #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE InstanceSigs #-}
 
 module Conjure.Language.Expression.Op.Restrict where
 
@@ -23,7 +24,7 @@ instance FromJSON  x => FromJSON  (OpRestrict x) where parseJSON = genericParseJ
 instance (TypeOf x, Pretty x, Domain () x :< x) => TypeOf (OpRestrict x) where
     typeOf p@(OpRestrict f domX) = do
         dom :: Domain () x   <- project domX
-        TypeFunction from to <- typeOf f
+        (from ,to )<- getFunctionTypes f
         from'                <- typeOfDomain dom
         if typesUnify [from, from']
             then return (TypeFunction (mostDefined [from', from]) to)
@@ -43,3 +44,6 @@ instance VarSymBreakingDescription x => VarSymBreakingDescription (OpRestrict x)
             , varSymBreakingDescription b
             ])
         ]
+
+
+    

--- a/src/Conjure/Language/Expression/Op/Restrict.hs
+++ b/src/Conjure/Language/Expression/Op/Restrict.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveGeneric, DeriveDataTypeable, DeriveFunctor, DeriveTraversable, DeriveFoldable #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE InstanceSigs #-}
 
 module Conjure.Language.Expression.Op.Restrict where
 
@@ -24,7 +23,7 @@ instance FromJSON  x => FromJSON  (OpRestrict x) where parseJSON = genericParseJ
 instance (TypeOf x, Pretty x, Domain () x :< x) => TypeOf (OpRestrict x) where
     typeOf p@(OpRestrict f domX) = do
         dom :: Domain () x   <- project domX
-        (from ,to )<- getFunctionTypes f
+        TypeFunction from to <- typeOf f
         from'                <- typeOfDomain dom
         if typesUnify [from, from']
             then return (TypeFunction (mostDefined [from', from]) to)
@@ -44,6 +43,3 @@ instance VarSymBreakingDescription x => VarSymBreakingDescription (OpRestrict x)
             , varSymBreakingDescription b
             ])
         ]
-
-
-    

--- a/src/Conjure/Language/Expression/Op/Xor.hs
+++ b/src/Conjure/Language/Expression/Op/Xor.hs
@@ -22,6 +22,8 @@ instance FromJSON  x => FromJSON  (OpXor x) where parseJSON = genericParseJSON j
 instance BinaryOperator (OpXor x) where
     opLexeme _ = L_Or
 
+
+
 instance (TypeOf x, Pretty x, ExpressionLike x) => TypeOf (OpXor x) where
     typeOf p@(OpXor x) = do
         ty <- typeOf x

--- a/src/Conjure/Language/Expression/Op/Xor.hs
+++ b/src/Conjure/Language/Expression/Op/Xor.hs
@@ -22,8 +22,6 @@ instance FromJSON  x => FromJSON  (OpXor x) where parseJSON = genericParseJSON j
 instance BinaryOperator (OpXor x) where
     opLexeme _ = L_Or
 
-
-
 instance (TypeOf x, Pretty x, ExpressionLike x) => TypeOf (OpXor x) where
     typeOf p@(OpXor x) = do
         ty <- typeOf x

--- a/src/Conjure/Language/Instantiate.hs
+++ b/src/Conjure/Language/Instantiate.hs
@@ -39,7 +39,6 @@ trySimplify ctxt x = do
 
 
 instantiateExpression ::
-    MonadFail m =>
     MonadFailDoc m =>
     EnumerateDomain m =>
     NameGen m =>
@@ -56,7 +55,6 @@ instantiateExpression ctxt x = do
 
 
 instantiateDomain ::
-    MonadFail m =>
     MonadFailDoc m =>
     EnumerateDomain m =>
     NameGen m =>
@@ -71,7 +69,6 @@ newtype HasUndef = HasUndef Any
     deriving (Semigroup, Monoid)
 
 instantiateE ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
@@ -81,7 +78,6 @@ instantiateE ::
 instantiateE (Comprehension body gensOrConds) = do
     let
         loop ::
-            MonadFail m =>
             MonadFailDoc m =>
             MonadState [(Name, Expression)] m =>
             EnumerateDomain m =>
@@ -200,7 +196,6 @@ instantiateE x = failDoc $ "instantiateE:" <+> pretty (show x)
 
 
 instantiateOp ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
@@ -212,7 +207,6 @@ instantiateOp opx = mapM instantiateE opx >>= evaluateOp . fmap normaliseConstan
 
 instantiateAbsLit ::
     MonadFailDoc m =>
-    MonadFail m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
     NameGen m =>
@@ -233,7 +227,6 @@ instantiateAbsLit x = do
 
 
 instantiateD ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
@@ -300,7 +293,6 @@ instantiateD DomainMetaVar{} = bug "instantiateD DomainMetaVar"
 
 
 instantiateSetAttr ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
@@ -311,7 +303,6 @@ instantiateSetAttr (SetAttr s) = SetAttr <$> instantiateSizeAttr s
 
 
 instantiateSizeAttr ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
@@ -326,7 +317,6 @@ instantiateSizeAttr (SizeAttr_MinMaxSize x y) = SizeAttr_MinMaxSize <$> instanti
 
 
 instantiateMSetAttr ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
@@ -337,7 +327,6 @@ instantiateMSetAttr (MSetAttr s o) = MSetAttr <$> instantiateSizeAttr s <*> inst
 
 
 instantiateOccurAttr ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
@@ -351,7 +340,6 @@ instantiateOccurAttr (OccurAttr_MinMaxOccur x y) = OccurAttr_MinMaxOccur <$> ins
 
 
 instantiateFunctionAttr ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
@@ -365,7 +353,6 @@ instantiateFunctionAttr (FunctionAttr s p j) =
 
 
 instantiateSequenceAttr ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadUserError m =>
     MonadState [(Name, Expression)] m =>
@@ -379,7 +366,6 @@ instantiateSequenceAttr (SequenceAttr s j) =
 
 
 instantiateRelationAttr ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadUserError m =>
     MonadState [(Name, Expression)] m =>
@@ -391,7 +377,6 @@ instantiateRelationAttr (RelationAttr s b) = RelationAttr <$> instantiateSizeAtt
 
 
 instantiatePartitionAttr ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadUserError m =>
     MonadState [(Name, Expression)] m =>
@@ -406,7 +391,6 @@ instantiatePartitionAttr (PartitionAttr a b r) =
 
 
 instantiateR ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>

--- a/src/Conjure/Language/Instantiate.hs
+++ b/src/Conjure/Language/Instantiate.hs
@@ -40,6 +40,7 @@ trySimplify ctxt x = do
 
 instantiateExpression ::
     MonadFail m =>
+    MonadFailDoc m =>
     EnumerateDomain m =>
     NameGen m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -56,6 +57,7 @@ instantiateExpression ctxt x = do
 
 instantiateDomain ::
     MonadFail m =>
+    MonadFailDoc m =>
     EnumerateDomain m =>
     NameGen m =>
     Pretty r =>
@@ -70,6 +72,7 @@ newtype HasUndef = HasUndef Any
 
 instantiateE ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
     NameGen m =>
@@ -79,6 +82,7 @@ instantiateE (Comprehension body gensOrConds) = do
     let
         loop ::
             MonadFail m =>
+            MonadFailDoc m =>
             MonadState [(Name, Expression)] m =>
             EnumerateDomain m =>
             NameGen m =>
@@ -152,7 +156,7 @@ instantiateE (Reference name refto) = do
                     -- reuse that
                     instantiateE x
                 _ -> 
-                    fail $ vcat
+                    failDoc $ vcat
                     $ ("No value for:" <+> pretty name)
                     : "Bindings in context:"
                     : prettyContext ctxt
@@ -168,7 +172,7 @@ instantiateE (Domain (DomainReference name Nothing)) = do
     ctxt <- gets id
     case name `lookup` ctxt of
         Just (Domain d) -> instantiateE (Domain d)
-        _ -> fail $ vcat
+        _ -> failDoc $ vcat
             $ ("No value for:" <+> pretty name)
             : "Bindings in context:"
             : prettyContext ctxt
@@ -180,8 +184,8 @@ instantiateE (WithLocals b (AuxiliaryVars locals)) = do
             constant <- instantiateE x
             case constant of
                 ConstantBool True -> return ()
-                _                 -> fail $ "local:" <+> pretty constant
-        _ -> fail $ "local:" <+> pretty local
+                _                 -> failDoc $ "local:" <+> pretty constant
+        _ -> failDoc $ "local:" <+> pretty local
     instantiateE b
 
 instantiateE (WithLocals b (DefinednessConstraints locals)) = do
@@ -189,14 +193,15 @@ instantiateE (WithLocals b (DefinednessConstraints locals)) = do
             constant <- instantiateE x
             case constant of
                 ConstantBool True -> return ()
-                _                 -> fail $ "local:" <+> pretty constant
+                _                 -> failDoc $ "local:" <+> pretty constant
     instantiateE b
 
-instantiateE x = fail $ "instantiateE:" <+> pretty (show x)
+instantiateE x = failDoc $ "instantiateE:" <+> pretty (show x)
 
 
 instantiateOp ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
     NameGen m =>
@@ -206,6 +211,7 @@ instantiateOp opx = mapM instantiateE opx >>= evaluateOp . fmap normaliseConstan
 
 
 instantiateAbsLit ::
+    MonadFailDoc m =>
     MonadFail m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
@@ -228,6 +234,7 @@ instantiateAbsLit x = do
 
 instantiateD ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
     NameGen m =>
@@ -250,8 +257,8 @@ instantiateD (DomainEnum nm Nothing _) = do
     st <- gets id
     case lookup nm st of
         Just (Domain dom) -> instantiateD (defRepr dom)
-        Just _  -> fail $ ("DomainEnum not found in state, Just:" <+> pretty nm) <++> vcat (map pretty st)
-        Nothing -> fail $ ("DomainEnum not found in state, Nothing:" <+> pretty nm) <++> vcat (map pretty st)
+        Just _  -> failDoc $ ("DomainEnum not found in state, Just:" <+> pretty nm) <++> vcat (map pretty st)
+        Nothing -> failDoc $ ("DomainEnum not found in state, Nothing:" <+> pretty nm) <++> vcat (map pretty st)
 instantiateD (DomainEnum nm rs0 _) = do
     let fmap4 = fmap . fmap . fmap . fmap
     let e2c' x = either bug id (e2c x)
@@ -260,8 +267,8 @@ instantiateD (DomainEnum nm rs0 _) = do
     st <- gets id
     mp <- forM (universeBi rs :: [Name]) $ \ n -> case lookup n st of
             Just (Constant (ConstantInt _ i)) -> return (n, i)
-            Nothing -> fail $ "No value for member of enum domain:" <+> pretty n
-            Just c  -> fail $ vcat [ "Incompatible value for member of enum domain:" <+> pretty nm
+            Nothing -> failDoc $ "No value for member of enum domain:" <+> pretty n
+            Just c  -> failDoc $ vcat [ "Incompatible value for member of enum domain:" <+> pretty nm
                                    , "    Looking up for member:" <+> pretty n
                                    , "    Expected an integer, but got:" <+> pretty c
                                    ]
@@ -285,7 +292,7 @@ instantiateD (DomainReference name Nothing) = do
     ctxt <- gets id
     case name `lookup` ctxt of
         Just (Domain d) -> instantiateD (defRepr d)
-        _ -> fail $ vcat
+        _ -> failDoc $ vcat
             $ ("No value for:" <+> pretty name)
             : "Bindings in context:"
             : prettyContext ctxt
@@ -294,6 +301,7 @@ instantiateD DomainMetaVar{} = bug "instantiateD DomainMetaVar"
 
 instantiateSetAttr ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
     NameGen m =>
@@ -304,6 +312,7 @@ instantiateSetAttr (SetAttr s) = SetAttr <$> instantiateSizeAttr s
 
 instantiateSizeAttr ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
     NameGen m =>
@@ -318,6 +327,7 @@ instantiateSizeAttr (SizeAttr_MinMaxSize x y) = SizeAttr_MinMaxSize <$> instanti
 
 instantiateMSetAttr ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
     NameGen m =>
@@ -328,6 +338,7 @@ instantiateMSetAttr (MSetAttr s o) = MSetAttr <$> instantiateSizeAttr s <*> inst
 
 instantiateOccurAttr ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
     NameGen m =>
@@ -341,6 +352,7 @@ instantiateOccurAttr (OccurAttr_MinMaxOccur x y) = OccurAttr_MinMaxOccur <$> ins
 
 instantiateFunctionAttr ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
     NameGen m =>
@@ -354,6 +366,7 @@ instantiateFunctionAttr (FunctionAttr s p j) =
 
 instantiateSequenceAttr ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadUserError m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
@@ -367,6 +380,7 @@ instantiateSequenceAttr (SequenceAttr s j) =
 
 instantiateRelationAttr ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadUserError m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
@@ -378,6 +392,7 @@ instantiateRelationAttr (RelationAttr s b) = RelationAttr <$> instantiateSizeAtt
 
 instantiatePartitionAttr ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadUserError m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
@@ -392,6 +407,7 @@ instantiatePartitionAttr (PartitionAttr a b r) =
 
 instantiateR ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     EnumerateDomain m =>
     NameGen m =>

--- a/src/Conjure/Language/Instantiate.hs-boot
+++ b/src/Conjure/Language/Instantiate.hs-boot
@@ -9,6 +9,7 @@ import Conjure.Process.Enumerate ( EnumerateDomain )
 
 instantiateExpression ::
     MonadFail m =>
+    MonadFailDoc m =>
     EnumerateDomain m =>
     NameGen m =>
     (?typeCheckerMode :: TypeCheckerMode) =>

--- a/src/Conjure/Language/Instantiate.hs-boot
+++ b/src/Conjure/Language/Instantiate.hs-boot
@@ -8,7 +8,6 @@ import Conjure.Process.Enumerate ( EnumerateDomain )
 
 
 instantiateExpression ::
-    MonadFail m =>
     MonadFailDoc m =>
     EnumerateDomain m =>
     NameGen m =>

--- a/src/Conjure/Language/Lenses.hs
+++ b/src/Conjure/Language/Lenses.hs
@@ -49,7 +49,7 @@ matchDefs fs inp =
 opMinus
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -68,7 +68,7 @@ opMinus _ =
 opDiv
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -87,7 +87,7 @@ opDiv _ =
 opMod
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -106,7 +106,7 @@ opMod _ =
 opPow
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -125,7 +125,7 @@ opPow _ =
 opNegate
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -144,7 +144,7 @@ opNegate _ =
 opDontCare
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -161,7 +161,7 @@ opDontCare _ =
 
 
 opDefined
-    :: MonadFail m
+    :: MonadFailDoc m
     => Proxy (m :: * -> *)
     -> ( Expression -> Expression
        , Expression -> m Expression
@@ -176,7 +176,7 @@ opDefined _ =
 
 
 opRange
-    :: MonadFail m
+    :: MonadFailDoc m
     => Proxy (m :: * -> *)
     -> ( Expression -> Expression
        , Expression -> m Expression
@@ -193,7 +193,7 @@ opRange _ =
 opDefinedOrRange
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( (x -> x, x) -> x
@@ -209,7 +209,7 @@ opDefinedOrRange _ =
 
 
 opRestrict
-    :: MonadFail m
+    :: MonadFailDoc m
     => Proxy (m :: * -> *)
     -> ( Expression -> Domain () Expression -> Expression
        , Expression -> m (Expression, Domain () Expression)
@@ -226,7 +226,7 @@ opRestrict _ =
 opToInt
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -245,7 +245,7 @@ opToInt _ =
 opPowerSet
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -264,7 +264,7 @@ opPowerSet _ =
 opToSet
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -283,7 +283,7 @@ opToSet _ =
 opToSetWithFlag
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( Bool -> x -> x
@@ -302,7 +302,7 @@ opToSetWithFlag _ =
 opToMSet
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -321,7 +321,7 @@ opToMSet _ =
 opToRelation
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -340,7 +340,7 @@ opToRelation _ =
 opParts
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -359,7 +359,7 @@ opParts _ =
 opParty
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -378,7 +378,7 @@ opParty _ =
 opParticipants
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -397,7 +397,7 @@ opParticipants _ =
 opImage
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -416,7 +416,7 @@ opImage _ =
 opImageSet
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -434,7 +434,7 @@ opImageSet _ =
 opTransform
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -453,7 +453,7 @@ opTransform _ =
 opRelationProj
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> [Maybe x] -> x
@@ -472,7 +472,7 @@ opRelationProj _ =
 opRelationImage
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> [x] -> x
@@ -494,7 +494,7 @@ opRelationImage _ =
 opIndexing
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -514,7 +514,7 @@ opMatrixIndexing
     :: ( Op x :< x
        , Pretty x
        , TypeOf x
-       , MonadFail m
+       , MonadFailDoc m
        , ?typeCheckerMode :: TypeCheckerMode
        )
     => Proxy (m :: * -> *)
@@ -545,7 +545,7 @@ opMatrixIndexing _ =
 opMatrixIndexingSlicing
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        , TypeOf x
        , ?typeCheckerMode :: TypeCheckerMode
        )
@@ -589,7 +589,7 @@ opMatrixIndexingSlicing _ =
 opSlicing
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> Maybe x -> Maybe x -> x
@@ -608,7 +608,7 @@ opSlicing _ =
 opFlatten
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -648,7 +648,7 @@ oneDimensionaliser dims x =
 opConcatenate
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -667,7 +667,7 @@ opConcatenate _ =
 opIn
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -686,7 +686,7 @@ opIn _ =
 opFreq
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -705,7 +705,7 @@ opFreq _ =
 opHist
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -724,7 +724,7 @@ opHist _ =
 opIntersect
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -743,7 +743,7 @@ opIntersect _ =
 opUnion
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -762,7 +762,7 @@ opUnion _ =
 opSubsetEq
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -781,7 +781,7 @@ opSubsetEq _ =
 opEq
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -800,7 +800,7 @@ opEq _ =
 opNeq
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -819,7 +819,7 @@ opNeq _ =
 opLt
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -838,7 +838,7 @@ opLt _ =
 opLeq
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -857,7 +857,7 @@ opLeq _ =
 opGt
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -876,7 +876,7 @@ opGt _ =
 opGeq
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -895,7 +895,7 @@ opGeq _ =
 opDotLt
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -914,7 +914,7 @@ opDotLt _ =
 opDotLeq
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -933,7 +933,7 @@ opDotLeq _ =
 opTildeLt
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -952,7 +952,7 @@ opTildeLt _ =
 opTildeLeq
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -971,7 +971,7 @@ opTildeLeq _ =
 opOr
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -990,7 +990,7 @@ opOr _ =
 opAnd
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -1009,7 +1009,7 @@ opAnd _ =
 opMax
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -1028,7 +1028,7 @@ opMax _ =
 opMin
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -1047,7 +1047,7 @@ opMin _ =
 opImply
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -1066,7 +1066,7 @@ opImply _ =
 opNot
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -1085,7 +1085,7 @@ opNot _ =
 opProduct
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -1104,7 +1104,7 @@ opProduct _ =
 opSum
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -1126,7 +1126,7 @@ data ReducerType = RepetitionIsNotSignificant | RepetitionIsSignificant
 opReducer
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( (x -> x, x) -> x
@@ -1156,7 +1156,7 @@ opReducer _ =
 
 opModifier
     :: ( Op x :< x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( (x -> x, x) -> x
@@ -1175,7 +1175,7 @@ opModifier _ =
 
 opModifierNoP
     :: ( Op x :< x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( (x -> x, x) -> x
@@ -1194,7 +1194,7 @@ opModifierNoP _ =
 opAllDiff
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -1213,7 +1213,7 @@ opAllDiff _ =
 opAllDiffExcept
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -1230,7 +1230,7 @@ opAllDiffExcept _ =
 
 
 constantInt
-    :: MonadFail m
+    :: MonadFailDoc m
     => Proxy (m :: * -> *)
     -> ( Integer -> Expression
        , Expression -> m Integer
@@ -1244,7 +1244,7 @@ constantInt _ =
 
 
 matrixLiteral
-    :: (MonadFail m, ?typeCheckerMode :: TypeCheckerMode)
+    :: (MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode)
     => Proxy (m :: * -> *)
     -> ( Type -> Domain () Expression -> [Expression] -> Expression
        , Expression -> m (Type, Domain () Expression, [Expression])
@@ -1298,7 +1298,7 @@ onMatrixLiteral mlvl f = case mlvl of
 
 
 setLiteral
-    :: (MonadFail m, ?typeCheckerMode :: TypeCheckerMode)
+    :: (MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode)
     => Proxy (m :: * -> *)
     -> ( Type -> [Expression] -> Expression
        , Expression -> m (Type, [Expression])
@@ -1322,7 +1322,7 @@ setLiteral _ =
 
 
 msetLiteral
-    :: (MonadFail m, ?typeCheckerMode :: TypeCheckerMode)
+    :: (MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode)
     => Proxy (m :: * -> *)
     -> ( Type -> [Expression] -> Expression
        , Expression -> m (Type, [Expression])
@@ -1346,7 +1346,7 @@ msetLiteral _ =
 
 
 functionLiteral
-    :: (MonadFail m, ?typeCheckerMode :: TypeCheckerMode)
+    :: (MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode)
     => Proxy (m :: * -> *)
     -> ( Type -> [(Expression,Expression)] -> Expression
        , Expression -> m (Type, [(Expression,Expression)])
@@ -1370,7 +1370,7 @@ functionLiteral _ =
 
 
 sequenceLiteral
-    :: (MonadFail m, ?typeCheckerMode :: TypeCheckerMode)
+    :: (MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode)
     => Proxy (m :: * -> *)
     -> ( Type -> [Expression] -> Expression
        , Expression -> m (Type, [Expression])
@@ -1394,7 +1394,7 @@ sequenceLiteral _ =
 
 
 relationLiteral
-    :: (MonadFail m, ?typeCheckerMode :: TypeCheckerMode)
+    :: (MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode)
     => Proxy (m :: * -> *)
     -> ( Type -> [[Expression]] -> Expression
        , Expression -> m (Type, [[Expression]])
@@ -1418,7 +1418,7 @@ relationLiteral _ =
 
 
 partitionLiteral
-    :: (MonadFail m, ?typeCheckerMode :: TypeCheckerMode)
+    :: (MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode)
     => Proxy (m :: * -> *)
     -> ( Type -> [[Expression]] -> Expression
        , Expression -> m (Type, [[Expression]])
@@ -1444,7 +1444,7 @@ partitionLiteral _ =
 opTwoBars
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -1463,7 +1463,7 @@ opTwoBars _ =
 opPreImage
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x -> x
@@ -1482,7 +1482,7 @@ opPreImage _ =
 opActive
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> Name -> x
@@ -1501,7 +1501,7 @@ opActive _ =
 opFactorial
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( x -> x
@@ -1520,7 +1520,7 @@ opFactorial _ =
 opLex
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( (x -> x -> x, (x,x)) -> x
@@ -1538,7 +1538,7 @@ opLex _ =
 opOrdering
     :: ( Op x :< x
        , Pretty x
-       , MonadFail m
+       , MonadFailDoc m
        )
     => Proxy (m :: * -> *)
     -> ( (x -> x -> x, (x,x)) -> x
@@ -1577,32 +1577,32 @@ fixRelationProj= transformBi f
                 _ -> p
 
 
-maxOfDomain :: (MonadFail m, Pretty r) => Domain r Expression -> m Expression
-maxOfDomain (DomainInt _ [] ) = fail "rule_DomainMinMax.maxOfDomain []"
+maxOfDomain :: (MonadFailDoc m, Pretty r) => Domain r Expression -> m Expression
+maxOfDomain (DomainInt _ [] ) = failDoc "rule_DomainMinMax.maxOfDomain []"
 maxOfDomain (DomainInt _ [r]) = maxOfRange r
 maxOfDomain (DomainInt _ rs ) = do
     xs <- mapM maxOfRange rs
     return (make opMax (fromList xs))
 maxOfDomain (DomainReference _ (Just d)) = maxOfDomain d
-maxOfDomain d = fail ("rule_DomainMinMax.maxOfDomain" <+> pretty d)
+maxOfDomain d = failDoc ("rule_DomainMinMax.maxOfDomain" <+> pretty d)
 
-maxOfRange :: MonadFail m => Range Expression -> m Expression
+maxOfRange :: MonadFailDoc m => Range Expression -> m Expression
 maxOfRange (RangeSingle x) = return x
 maxOfRange (RangeBounded _ x) = return x
 maxOfRange (RangeUpperBounded x) = return x
-maxOfRange r = fail ("rule_DomainMinMax.maxOfRange" <+> pretty (show r))
+maxOfRange r = failDoc ("rule_DomainMinMax.maxOfRange" <+> pretty (show r))
 
-minOfDomain :: (MonadFail m, Pretty r) => Domain r Expression -> m Expression
-minOfDomain (DomainInt _ [] ) = fail "rule_DomainMinMax.minOfDomain []"
+minOfDomain :: (MonadFailDoc m, Pretty r) => Domain r Expression -> m Expression
+minOfDomain (DomainInt _ [] ) = failDoc "rule_DomainMinMax.minOfDomain []"
 minOfDomain (DomainInt _ [r]) = minOfRange r
 minOfDomain (DomainInt _ rs ) = do
     xs <- mapM minOfRange rs
     return (make opMin (fromList xs))
 minOfDomain (DomainReference _ (Just d)) = minOfDomain d
-minOfDomain d = fail ("rule_DomainMinMax.minOfDomain" <+> pretty d)
+minOfDomain d = failDoc ("rule_DomainMinMax.minOfDomain" <+> pretty d)
 
-minOfRange :: MonadFail m => Range Expression -> m Expression
+minOfRange :: MonadFailDoc m => Range Expression -> m Expression
 minOfRange (RangeSingle x) = return x
 minOfRange (RangeBounded x _) = return x
 minOfRange (RangeLowerBounded x) = return x
-minOfRange r = fail ("rule_DomainMinMax.minOfRange" <+> pretty (show r))
+minOfRange r = failDoc ("rule_DomainMinMax.minOfRange" <+> pretty (show r))

--- a/src/Conjure/Language/Lexer.hs
+++ b/src/Conjure/Language/Lexer.hs
@@ -488,7 +488,7 @@ lexemes = sortBy (flip (comparing (T.length . fst))) $ map swap
     , ( L_transform, "transform")
     ]
 
-runLexer :: MonadFail m => T.Text -> m [LexemePos]
+runLexer :: MonadFailDoc m => T.Text -> m [LexemePos]
 runLexer text = do
     ls <- go text
     let lsPaired = calcPos (initialPos "") ls
@@ -505,7 +505,7 @@ runLexer text = do
             if T.null t
                 then return []
                 else case results of
-                        [] -> fail ("Lexing error:" Pr.<+> Pr.text (T.unpack t))
+                        [] -> failDoc ("Lexing error:" Pr.<+> Pr.text (T.unpack t))
                         ((rest,lexeme):_) -> (lexeme:) <$> go rest
 
         -- attach source positions to lexemes

--- a/src/Conjure/Language/NameGen.hs
+++ b/src/Conjure/Language/NameGen.hs
@@ -97,14 +97,14 @@ instance (Functor m, Monad m) => NameGen (NameGenM m) where
     importNameGenState st = modify $ \ (_, avoid) -> (M.fromList st, avoid)
 
 instance NameGen (Either Doc) where
-    nextName _ = fail "nextName{Either Doc}"
-    exportNameGenState = fail "exportNameGenState{Either Doc}"
-    importNameGenState _ = fail "importNameGenState{Either Doc}"
+    nextName _ = failDoc "nextName{Either Doc}"
+    exportNameGenState = failDoc "exportNameGenState{Either Doc}"
+    importNameGenState _ = failDoc "importNameGenState{Either Doc}"
 
 instance NameGen Identity where
-    nextName _ = fail "nextName{Identity}"
-    exportNameGenState = fail "exportNameGenState{Identity}"
-    importNameGenState _ = fail "importNameGenState{Identity}"
+    nextName _ = failDoc "nextName{Identity}"
+    exportNameGenState = failDoc "exportNameGenState{Identity}"
+    importNameGenState _ = failDoc "importNameGenState{Identity}"
 
 runNameGen :: (Monad m, Data x) => x -> NameGenM m a -> m a
 runNameGen avoid (NameGenM comp) =

--- a/src/Conjure/Language/NameGen.hs
+++ b/src/Conjure/Language/NameGen.hs
@@ -39,6 +39,8 @@ newtype NameGenM m a = NameGenM (StateT NameGenState m a)
              , MonadIO
              )
 
+instance (Functor m,Applicative m , Monad m,MonadFail m) => MonadFailDoc (NameGenM m) where
+    failDoc = lift . fail . show
 class (Functor m, Applicative m, Monad m) => NameGen m where
     nextName :: NameKind -> m Name
     exportNameGenState :: m [(NameKind, Int)]
@@ -106,7 +108,7 @@ instance NameGen Identity where
     exportNameGenState = failDoc "exportNameGenState{Identity}"
     importNameGenState _ = failDoc "importNameGenState{Identity}"
 
-runNameGen :: (Monad m, Data x) => x -> NameGenM m a -> m a
+runNameGen :: (Monad m, Data x,MonadFailDoc m,MonadFail m) => x -> NameGenM m a -> m a
 runNameGen avoid (NameGenM comp) =
     let initState = (M.empty, S.fromList (universeBi avoid))
     in  evalStateT comp initState

--- a/src/Conjure/Language/NameResolution.hs
+++ b/src/Conjure/Language/NameResolution.hs
@@ -180,7 +180,7 @@ resolveX (Reference nm Nothing) = do
 resolveX p@(Reference nm (Just refto)) = do             -- this is for re-resolving
     mval <- gets (lookup nm)
     case mval of
-        Nothing -> return p                             -- hence, do not failDoc if not in the context
+        Nothing -> return p                             -- hence, do not fail if not in the context
         Just DeclNoRepr{}                               -- if the newly found guy doesn't have a repr
             | DeclHasRepr{} <- refto                    -- but the old one did, do not update
             -> return p

--- a/src/Conjure/Language/NameResolution.hs
+++ b/src/Conjure/Language/NameResolution.hs
@@ -53,7 +53,7 @@ resolveNames_ model = failToUserError $ do
 -- this is for when a name will shadow an already existing name that is outside of this expression
 -- we rename the new names to avoid name shadowing
 shadowing ::
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, ReferenceTo)] m =>
     NameGen m =>
     Expression -> m Expression
@@ -75,7 +75,7 @@ shadowing p = return p
 
 
 resolveNamesX ::
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadUserError m =>
     NameGen m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -94,13 +94,13 @@ toTaggedInt = transformBi f
         f ty = ty
 
 
-check :: MonadFail m => Expression -> m ()
-check (Reference nm Nothing) = fail ("Undefined:" <+> pretty nm)
+check :: MonadFailDoc m => Expression -> m ()
+check (Reference nm Nothing) = failDoc ("Undefined:" <+> pretty nm)
 check _ = return ()
 
 
 resolveStatement ::
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, ReferenceTo)] m =>
     MonadUserError m =>
     NameGen m =>
@@ -143,7 +143,7 @@ resolveStatement st =
 
 
 resolveSearchOrder ::
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, ReferenceTo)] m =>
     MonadUserError m =>
     NameGen m =>
@@ -163,7 +163,7 @@ resolveSearchOrder (Cut x) =
 
 
 resolveX ::
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, ReferenceTo)] m =>
     MonadUserError m =>
     NameGen m =>
@@ -180,7 +180,7 @@ resolveX (Reference nm Nothing) = do
 resolveX p@(Reference nm (Just refto)) = do             -- this is for re-resolving
     mval <- gets (lookup nm)
     case mval of
-        Nothing -> return p                             -- hence, do not fail if not in the context
+        Nothing -> return p                             -- hence, do not failDoc if not in the context
         Just DeclNoRepr{}                               -- if the newly found guy doesn't have a repr
             | DeclHasRepr{} <- refto                    -- but the old one did, do not update
             -> return p
@@ -250,7 +250,7 @@ resolveX x = descendM resolveX x
 
 
 resolveD ::
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, ReferenceTo)] m =>
     MonadUserError m =>
     NameGen m =>
@@ -308,7 +308,7 @@ resolveAbsPat context (AbsPatSet ps) x = do
 
 
 resolveAbsLit ::
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, ReferenceTo)] m =>
     MonadUserError m =>
     NameGen m =>

--- a/src/Conjure/Language/ParserC.hs
+++ b/src/Conjure/Language/ParserC.hs
@@ -37,12 +37,12 @@ parseModel = inCompleteFile $ do
             -- ESSENCE' is accepted, just for convenience
             unless (l `elem` ["Essence", "ESSENCE", "ESSENCE'"]) $ do
                 setPosition pos1
-                fail $ "language name has to be Essence, but given:" <+> pretty l
+                failDoc $ "language name has to be Essence, but given:" <+> pretty l
             pos2 <- getPosition
             is <- sepBy1 integer dot
             unless (is >= [1]) $ do
                 setPosition pos2
-                fail $ "language version expected to be at least 1.0, but given:" <+>
+                failDoc $ "language version expected to be at least 1.0, but given:" <+>
                             pretty (intercalate "." (map show is))
             return (LanguageVersion (Name l) (map fromInteger is))
     l  <- optional pLanguage
@@ -232,7 +232,7 @@ parseDomainWithRepr = pDomainAtom
             let RelationAttr _ (BinaryRelationAttrs binAttrs) = x
             when (length ys /= 2 && not (S.null binAttrs)) $ do
                 setPosition pos
-                fail $ "Only binary relations can have these attributes:" <+>
+                failDoc $ "Only binary relations can have these attributes:" <+>
                             prettyList id "," (S.toList binAttrs)
             return $ DomainRelation NoRepresentation x ys
 
@@ -267,7 +267,7 @@ parseSetAttr = do
         [DANameValue "maxSize" b, DANameValue "minSize" a] -> return (SizeAttr_MinMaxSize a b)
         as -> do
             setPosition pos
-            fail ("incompatible attributes:" <+> stringToDoc (show as))
+            failDoc ("incompatible attributes:" <+> stringToDoc (show as))
 
 parseMSetAttr :: Parser (MSetAttr Expression)
 parseMSetAttr = do
@@ -285,7 +285,7 @@ parseMSetAttr = do
         [DANameValue "maxSize" b, DANameValue "minSize" a] -> return (SizeAttr_MinMaxSize a b)
         as -> do
             setPosition pos
-            fail ("incompatible attributes:" <+> stringToDoc (show as))
+            failDoc ("incompatible attributes:" <+> stringToDoc (show as))
     occur <- case filterAttrName ["minOccur", "maxOccur"] attrs of
         [] -> return OccurAttr_None
         [DANameValue "minOccur" a] -> return (OccurAttr_MinOccur a)
@@ -293,7 +293,7 @@ parseMSetAttr = do
         [DANameValue "maxOccur" b, DANameValue "minOccur" a] -> return (OccurAttr_MinMaxOccur a b)
         as -> do
             setPosition pos
-            fail ("incompatible attributes:" <+> stringToDoc (show as))
+            failDoc ("incompatible attributes:" <+> stringToDoc (show as))
     return (MSetAttr size occur)
 
 parseFunctionAttr :: Parser (FunctionAttr Expression)
@@ -313,7 +313,7 @@ parseFunctionAttr = do
         [] -> return SizeAttr_None
         as -> do
             setPosition pos
-            fail ("incompatible attributes:" <+> stringToDoc (show as))
+            failDoc ("incompatible attributes:" <+> stringToDoc (show as))
     let partiality = if DAName "total" `elem` attrs
                         then PartialityAttr_Total
                         else PartialityAttr_Partial
@@ -325,7 +325,7 @@ parseFunctionAttr = do
         [DAName "injective", DAName "surjective"] -> return JectivityAttr_Bijective
         as -> do
             setPosition pos
-            fail ("incompatible attributes:" <+> stringToDoc (show as))
+            failDoc ("incompatible attributes:" <+> stringToDoc (show as))
     return (FunctionAttr size partiality jectivity)
 
 parseSequenceAttr :: Parser (SequenceAttr Expression)
@@ -344,7 +344,7 @@ parseSequenceAttr = do
         [] -> return SizeAttr_None
         as -> do
             setPosition pos
-            fail ("incompatible attributes:" <+> stringToDoc (show as))
+            failDoc ("incompatible attributes:" <+> stringToDoc (show as))
     jectivity  <- case filterJectivity attrs of
         [] -> return JectivityAttr_None
         [DAName "bijective" ] -> return JectivityAttr_Bijective
@@ -353,7 +353,7 @@ parseSequenceAttr = do
         [DAName "injective", DAName "surjective"] -> return JectivityAttr_Bijective
         as -> do
             setPosition pos
-            fail ("incompatible attributes:" <+> stringToDoc (show as))
+            failDoc ("incompatible attributes:" <+> stringToDoc (show as))
     return (SequenceAttr size jectivity)
 
 parseRelationAttr :: Parser (RelationAttr Expression)
@@ -369,11 +369,11 @@ parseRelationAttr = do
         [DANameValue "maxSize" b, DANameValue "minSize" a] -> return (SizeAttr_MinMaxSize a b)
         as -> do
             setPosition pos
-            fail ("incompatible attributes:" <+> stringToDoc (show as))
+            failDoc ("incompatible attributes:" <+> stringToDoc (show as))
     let readBinRel' (DAName (Name a)) = readBinRel (fromString (textToString a))
         readBinRel' a = do
             setPosition pos
-            fail $ "Not a binary relation attribute:" <+> pretty a
+            failDoc $ "Not a binary relation attribute:" <+> pretty a
     binRels <- mapM readBinRel' (filterBinRel attrs)
     return (RelationAttr size (BinaryRelationAttrs (S.fromList binRels)))
 
@@ -389,12 +389,12 @@ parsePartitionAttr = do
         ]
     unless (null $ filterAttrName ["complete"] attrs) $ do
         setPosition pos
-        fail $ vcat [ "Partitions do not support the 'complete' attribute."
+        failDoc $ vcat [ "Partitions do not support the 'complete' attribute."
                     , "They are complete by default."
                     ]
     unless (null $ filterSizey attrs) $ do
         setPosition pos
-        fail $ vcat [ "Partitions do not support these attributes:" <+> prettyList id "," (filterSizey attrs)
+        failDoc $ vcat [ "Partitions do not support these attributes:" <+> prettyList id "," (filterSizey attrs)
                     , "This is because partitions are complete by default."
                     ]
     partsNum         <- case filterAttrName ["numParts", "minNumParts", "maxNumParts"] attrs of
@@ -405,7 +405,7 @@ parsePartitionAttr = do
         [DANameValue "maxNumParts" b, DANameValue "minNumParts" a] -> return (SizeAttr_MinMaxSize a b)
         as -> do
             setPosition pos
-            fail ("incompatible attributes:" <+> stringToDoc (show as))
+            failDoc ("incompatible attributes:" <+> stringToDoc (show as))
     partsSize        <- case filterAttrName ["partSize", "minPartSize", "maxPartSize"] attrs of
         [] -> return SizeAttr_None
         [DANameValue "partSize"    a] -> return (SizeAttr_Size a)
@@ -414,7 +414,7 @@ parsePartitionAttr = do
         [DANameValue "maxPartSize" b, DANameValue "minPartSize" a] -> return (SizeAttr_MinMaxSize a b)
         as -> do
             setPosition pos
-            fail ("incompatible attributes:" <+> stringToDoc (show as))
+            failDoc ("incompatible attributes:" <+> stringToDoc (show as))
     let isRegular  = DAName "regular"  `elem` attrs
     return PartitionAttr {..}
 
@@ -424,7 +424,7 @@ checkExtraAttributes pos ty attrs supported = do
     let extras = mapMaybe f attrs
     unless (null extras) $ do
         setPosition pos
-        fail $ vcat [ "Unsupported attributes for" <+> ty <> ":" <+> prettyList id "," extras
+        failDoc $ vcat [ "Unsupported attributes for" <+> ty <> ":" <+> prettyList id "," extras
                     , "Only these are supported:" <+> prettyList id "," supported
                     ]
     where
@@ -589,7 +589,7 @@ parseLiteral = label "value" (do p <- pCore ; p)
             xsFiltered <- forM xs $ \case
                 Constant (ConstantAbstract (AbsLitTuple is)) -> return (map Constant is)
                 AbstractLiteral (AbsLitTuple is) -> return is
-                x -> fail ("Cannot parse as part of relation literal:" <+> vcat [pretty x, pretty (show x)])
+                x -> failDoc ("Cannot parse as part of relation literal:" <+> vcat [pretty x, pretty (show x)])
             return (AbsLitRelation xsFiltered)
 
         pPartition = mkAbstractLiteral <$> do

--- a/src/Conjure/Language/RepresentationOf.hs
+++ b/src/Conjure/Language/RepresentationOf.hs
@@ -8,32 +8,32 @@ import Conjure.Language.Type ( TypeCheckerMode )
 
 class RepresentationOf a where
     representationTreeOf
-        :: (MonadFail m, ?typeCheckerMode :: TypeCheckerMode)
+        :: (MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode)
         => a -> m (Tree (Maybe HasRepresentation))
 
-representationOf :: (RepresentationOf a, MonadFail m, ?typeCheckerMode :: TypeCheckerMode) => a -> m HasRepresentation
+representationOf :: (RepresentationOf a, MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode) => a -> m HasRepresentation
 representationOf a = do
     tree <- representationTreeOf a
     case rootLabel tree of
-        Nothing               -> fail "doesn't seem to have a representation"
-        Just NoRepresentation -> fail "doesn't seem to have a representation"
+        Nothing               -> failDoc "doesn't seem to have a representation"
+        Just NoRepresentation -> failDoc "doesn't seem to have a representation"
         Just r -> return r
 
-hasRepresentation :: (RepresentationOf a, MonadFail m, ?typeCheckerMode :: TypeCheckerMode) => a -> m ()
+hasRepresentation :: (RepresentationOf a, MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode) => a -> m ()
 hasRepresentation x =
     case representationOf x of
-        Nothing -> fail "doesn't seem to have a representation"
+        Nothing -> failDoc "doesn't seem to have a representation"
         Just _  -> return ()
 
-sameRepresentation :: (RepresentationOf a, MonadFail m, ?typeCheckerMode :: TypeCheckerMode) => a -> a -> m ()
+sameRepresentation :: (RepresentationOf a, MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode) => a -> a -> m ()
 sameRepresentation x y =
     case (representationOf x, representationOf y) of
         (Just rx, Just ry) | rx == ry -> return ()
-        _ -> fail "doesn't seem to have the same representation"
+        _ -> failDoc "doesn't seem to have the same representation"
 
-sameRepresentationTree :: (RepresentationOf a, MonadFail m, ?typeCheckerMode :: TypeCheckerMode) => a -> a -> m ()
+sameRepresentationTree :: (RepresentationOf a, MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode) => a -> a -> m ()
 sameRepresentationTree x y = do
     xTree <- representationTreeOf x
     yTree <- representationTreeOf y
     unless (xTree == yTree) $
-        fail "doesn't seem to have the same representation tree"
+        failDoc "doesn't seem to have the same representation tree"

--- a/src/Conjure/Language/Type.hs
+++ b/src/Conjure/Language/Type.hs
@@ -213,18 +213,18 @@ matrixNumDims (TypeList     t) = 1 + matrixNumDims t
 matrixNumDims _ = 0
 
 homoType ::
-    MonadFail m =>
+    MonadFailDoc m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
     Doc -> [Type] -> m Type
-homoType msg [] = fail $ "empty collection, what's the type?" <++> ("When working on:" <+> msg)
+homoType msg [] = failDoc $ "empty collection, what's the type?" <++> ("When working on:" <+> msg)
 homoType msg xs =
     if typesUnify xs
         then return (mostDefined xs)
-        else fail $ vcat [ "Not uniformly typed:" <+> msg
+        else failDoc $ vcat [ "Not uniformly typed:" <+> msg
                          , "Involved types are:" <+> vcat (map pretty xs)
                          ]
 
-innerTypeOf :: MonadFail m => Type -> m Type
+innerTypeOf :: MonadFailDoc m => Type -> m Type
 innerTypeOf (TypeList t) = return t
 innerTypeOf (TypeMatrix _ t) = return t
 innerTypeOf (TypeSet t) = return t
@@ -233,7 +233,7 @@ innerTypeOf (TypeFunction a b) = return (TypeTuple [a,b])
 innerTypeOf (TypeSequence t) = return (TypeTuple [TypeInt TagInt,t])
 innerTypeOf (TypeRelation ts) = return (TypeTuple ts)
 innerTypeOf (TypePartition t) = return (TypeSet t)
-innerTypeOf t = fail ("innerTypeOf:" <+> pretty (show t))
+innerTypeOf t = failDoc ("innerTypeOf:" <+> pretty (show t))
 
 isPrimitiveType :: Type -> Bool
 isPrimitiveType TypeBool{} = True
@@ -287,9 +287,8 @@ unifiesOrContains container containee =
 
 -- as in "this homomorphism is morphing"
 morphing :: (?typeCheckerMode :: TypeCheckerMode)
-         => (MonadFail m)
+         => (MonadFailDoc m)
          => Type -> m Type
 morphing (TypeFunction a _) = return a
 morphing (TypeSequence a)   = return a 
-morphing t = fail ("morphing:" <+> pretty (show t))
-
+morphing t = failDoc ("morphing:" <+> pretty (show t))

--- a/src/Conjure/Language/TypeOf.hs
+++ b/src/Conjure/Language/TypeOf.hs
@@ -14,5 +14,3 @@ class TypeOf a where
     -- RelaxedIntegerTags is for internal use only and it ignores the integer tags during type checking.
 
     typeOf :: (MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode) => a -> m Type
-
-

--- a/src/Conjure/Language/TypeOf.hs
+++ b/src/Conjure/Language/TypeOf.hs
@@ -13,4 +13,6 @@ class TypeOf a where
     -- StronglyTyped is used for user input.
     -- RelaxedIntegerTags is for internal use only and it ignores the integer tags during type checking.
 
-    typeOf :: (MonadFail m, ?typeCheckerMode :: TypeCheckerMode) => a -> m Type
+    typeOf :: (MonadFailDoc m, ?typeCheckerMode :: TypeCheckerMode) => a -> m Type
+
+

--- a/src/Conjure/Language/ZeroVal.hs
+++ b/src/Conjure/Language/ZeroVal.hs
@@ -26,7 +26,7 @@ zeroVal (DomainMatrix index inner) = do
     z  <- zeroVal inner
     is <- case index of
             DomainInt _ rs -> rangesInts rs
-            _ -> fail $ "Matrix indexed by a domain that isn't int:" <+> pretty index
+            _ -> failDoc $ "Matrix indexed by a domain that isn't int:" <+> pretty index
     return $ ConstantAbstract $ AbsLitMatrix index $ replicate (length is) z
 zeroVal d@(DomainSet _ (SetAttr sizeAttr) inner) = do
     z       <- zeroVal inner
@@ -64,15 +64,15 @@ zeroVal d@(DomainPartition _ (PartitionAttr numPartsAttr partSizeAttr _) inner) 
 zeroVal d = bug $ "No 'zero' value for domain:" <+> pretty d
 
 
-zeroValR :: MonadFail m => Range a -> m a
-zeroValR RangeOpen = fail "No 'zero' value for an open range."
+zeroValR :: MonadFailDoc m => Range a -> m a
+zeroValR RangeOpen = failDoc "No 'zero' value for an open range."
 zeroValR (RangeSingle x) = return x
 zeroValR (RangeLowerBounded x) = return x
 zeroValR (RangeUpperBounded x) = return x
 zeroValR (RangeBounded x _) = return x
 
 
-getMin :: (MonadFail m, Pretty r, Pretty x) => Domain r x -> SizeAttr Constant -> m Integer
+getMin :: (MonadFailDoc m, Pretty r, Pretty x) => Domain r x -> SizeAttr Constant -> m Integer
 getMin _ SizeAttr_None = return 0
 getMin d (SizeAttr_Size x) = returnInt d x
 getMin d (SizeAttr_MinSize x) = returnInt d x
@@ -80,6 +80,6 @@ getMin _ (SizeAttr_MaxSize _) = return 0
 getMin d (SizeAttr_MinMaxSize x _) = returnInt d x
 
 
-returnInt :: (MonadFail m, Pretty r, Pretty x) => Domain r x -> Constant -> m Integer
+returnInt :: (MonadFailDoc m, Pretty r, Pretty x) => Domain r x -> Constant -> m Integer
 returnInt _ (ConstantInt _ x) = return x
-returnInt d _ = fail $ "Attribute expected to be an int in:" <+> pretty d
+returnInt d _ = failDoc $ "Attribute expected to be an int in:" <+> pretty d

--- a/src/Conjure/Language/ZeroVal.hs
+++ b/src/Conjure/Language/ZeroVal.hs
@@ -9,7 +9,7 @@ import Conjure.Language.Pretty
 import Conjure.Process.Enumerate ( EnumerateDomain, enumerateDomain )
 
 
-zeroVal :: (MonadFail m, EnumerateDomain m, Pretty r) => Domain r Constant -> m Constant
+zeroVal :: (MonadFailDoc m, EnumerateDomain m, Pretty r) => Domain r Constant -> m Constant
 zeroVal DomainBool = return $ ConstantBool False
 zeroVal (DomainInt t []) = return $ ConstantInt t 0
 zeroVal (DomainInt _ (r:_)) = zeroValR r

--- a/src/Conjure/Prelude.hs
+++ b/src/Conjure/Prelude.hs
@@ -30,7 +30,7 @@ module Conjure.Prelude
     , allNats
     , jsonOptions
     , Proxy(..)
-    , MonadFailDoc(..), failCheaply, na
+    , MonadFailDoc(..), na
     , MonadFail (..)
     , allContexts, ascendants
     , dropExtension, dropDirs
@@ -462,15 +462,6 @@ instance MonadState s m => MonadState s (ExceptT m) where
     get = lift get
     put = lift . put
 
-
--- | "failCheaply: premature optimisation at its finest." - Oz
---   If you have a (MonadFailDoc m => m a) action at hand which doesn't require anything else from the monad m,
---   it can be run in any monad that implements MonadFailDoc.
---   Running it in a monad like IO will be a little bit more expensive though.
---   Why not run it in Either and raise the error in the outer monad instead?
---   Notice: this function cannot be eta-reduced.
-failCheaply :: MonadFailDoc m2 => (forall m . MonadFailDoc m => m a) -> m2 a
-failCheaply m = either failDoc return m
 
 
 allContexts :: Data b => Zipper a b -> [Zipper a b]

--- a/src/Conjure/Prelude.hs
+++ b/src/Conjure/Prelude.hs
@@ -388,6 +388,9 @@ instance MonadFailDoc Maybe where
 instance (a ~ Doc) => MonadFailDoc (Either a) where
     failDoc = Left
 
+instance MonadFail (Either Doc) where
+    fail = failDoc . stringToDoc
+
 instance MonadFailDoc m => MonadFailDoc (IdentityT m) where
     failDoc = lift . failDoc
 
@@ -437,7 +440,8 @@ instance (Monad m) => Monad (ExceptT m) where
             Right x -> runExceptT (k x)
     -- fail = ExceptT . return . Left . stringToDoc
 
-instance (MonadFail m) => MonadFail (ExceptT m) where
+
+instance (MonadFailDoc m) => MonadFail (ExceptT m) where
     fail = ExceptT . return . Left . stringToDoc
 
 instance MonadIO m => MonadIO (ExceptT m) where

--- a/src/Conjure/Prelude.hs
+++ b/src/Conjure/Prelude.hs
@@ -30,7 +30,8 @@ module Conjure.Prelude
     , allNats
     , jsonOptions
     , Proxy(..)
-    , MonadFail(..), failCheaply, na
+    , MonadFailDoc(..), failCheaply, na
+    , MonadFail (..)
     , allContexts, ascendants
     , dropExtension, dropDirs
     , MonadLog(..), LogLevel(..), runLoggerPipeIO, ignoreLogs
@@ -76,6 +77,7 @@ import GHC.Generics as X ( Generic )
 import Data.Functor as X ( Functor(..) )
 import Control.Applicative as X ( Applicative(..), (<$>), (<*), (*>), (<|>), many, some, optional )
 import qualified Control.Monad ( fail )
+import Control.Monad.Fail 
 
 import Control.Monad                as X ( Monad(return, (>>), (>>=))
                                          , (<=<), (>=>), (=<<), ap, join
@@ -328,7 +330,7 @@ padShowInt n i = let s = show i in replicate (n - length s) '0' ++ s
 decodeFromFile :: (Serialize a, MonadFail IO) => FilePath -> IO a
 decodeFromFile path = do
     con <- ByteString.readFile path
-    either (fail . stringToDoc) return (decode con)
+    either (fail) return (decode con)
 
 class Monad m => RandomM m where
     get_stdgen :: m StdGen
@@ -371,50 +373,50 @@ jsonOptions = JSON.defaultOptions
     }
 
 
-class (Functor m, Applicative m, Monad m) => MonadFail m where
-    fail :: Doc -> m a
+class (Functor m, Applicative m, Monad m) => MonadFailDoc m where
+    failDoc :: Doc -> m a
 
-na :: MonadFail m => Doc -> m a
-na message = fail ("N/A:" <+> message)
+na :: MonadFailDoc m => Doc -> m a
+na message = failDoc ("N/A:" <+> message)
 
-instance MonadFail Identity where
-    fail = Control.Monad.fail . show
+instance MonadFailDoc Identity where
+    failDoc = Control.Monad.fail . show
 
-instance MonadFail Maybe where
-    fail = const Nothing
+instance MonadFailDoc Maybe where
+    failDoc = const Nothing
 
-instance (a ~ Doc) => MonadFail (Either a) where
-    fail = Left
+instance (a ~ Doc) => MonadFailDoc (Either a) where
+    failDoc = Left
 
-instance MonadFail m => MonadFail (IdentityT m) where
-    fail = lift . fail
+instance MonadFailDoc m => MonadFailDoc (IdentityT m) where
+    failDoc = lift . failDoc
 
-instance (Functor m, Monad m) => MonadFail (MaybeT m) where
-    fail = const $ MaybeT $ return Nothing
+instance (Functor m, Monad m) => MonadFailDoc (MaybeT m) where
+    failDoc = const $ MaybeT $ return Nothing
 
-instance (Functor m, Monad m) => MonadFail (ExceptT m) where
-    fail = ExceptT . return . Left
+instance (Functor m, Monad m) => MonadFailDoc (ExceptT m) where
+    failDoc = ExceptT . return . Left
 
-instance (Functor m, Monad m, MonadFail m) => MonadFail (StateT st m) where
-    fail = lift . fail
+instance (Functor m, Monad m, MonadFailDoc m) => MonadFailDoc (StateT st m) where
+    failDoc = lift . failDoc
 
-instance (MonadFail m, Monoid w) => MonadFail (WriterT w m) where
-    fail = lift . fail
+instance (MonadFailDoc m, Monoid w) => MonadFailDoc (WriterT w m) where
+    failDoc = lift . failDoc
 
-instance MonadFail m => MonadFail (ReaderT r m) where
-    fail = lift . fail
+instance MonadFailDoc m => MonadFailDoc (ReaderT r m) where
+    failDoc = lift . failDoc
 
-instance MonadFail Gen where
-    fail = Control.Monad.fail . show
+instance MonadFailDoc Gen where
+    failDoc = Control.Monad.fail . show
 
-instance MonadFail (ParsecT l m) where
-    fail = Control.Monad.fail . show
+instance MonadFailDoc (ParsecT l m) where
+    failDoc = Control.Monad.fail . show
 
-instance MonadFail m => MonadFail (Pipes.Proxy a b c d m) where
-    fail = lift . fail
+instance MonadFailDoc m => MonadFailDoc (Pipes.Proxy a b c d m) where
+    failDoc = lift . failDoc
 
-instance MonadFail TH.Q where
-    fail = Control.Monad.fail . show
+instance MonadFailDoc TH.Q where
+    failDoc = Control.Monad.fail . show
 
 
 newtype ExceptT m a = ExceptT { runExceptT :: m (Either Doc a) }
@@ -433,6 +435,9 @@ instance (Monad m) => Monad (ExceptT m) where
         case a of
             Left e -> return (Left e)
             Right x -> runExceptT (k x)
+    -- fail = ExceptT . return . Left . stringToDoc
+
+instance (MonadFail m) => MonadFail (ExceptT m) where
     fail = ExceptT . return . Left . stringToDoc
 
 instance MonadIO m => MonadIO (ExceptT m) where
@@ -451,13 +456,13 @@ instance MonadState s m => MonadState s (ExceptT m) where
 
 
 -- | "failCheaply: premature optimisation at its finest." - Oz
---   If you have a (MonadFail m => m a) action at hand which doesn't require anything else from the monad m,
---   it can be run in any monad that implements MonadFail.
+--   If you have a (MonadFailDoc m => m a) action at hand which doesn't require anything else from the monad m,
+--   it can be run in any monad that implements MonadFailDoc.
 --   Running it in a monad like IO will be a little bit more expensive though.
 --   Why not run it in Either and raise the error in the outer monad instead?
 --   Notice: this function cannot be eta-reduced.
-failCheaply :: MonadFail m2 => (forall m . MonadFail m => m a) -> m2 a
-failCheaply m = either fail return m
+failCheaply :: MonadFailDoc m2 => (forall m . MonadFailDoc m => m a) -> m2 a
+failCheaply m = either failDoc return m
 
 
 allContexts :: Data b => Zipper a b -> [Zipper a b]

--- a/src/Conjure/Prelude.hs
+++ b/src/Conjure/Prelude.hs
@@ -373,12 +373,14 @@ jsonOptions = JSON.defaultOptions
     }
 
 
-class (Functor m, Applicative m, Monad m) => MonadFailDoc m where
+class (Functor m, Applicative m, Monad m,MonadFail m) => MonadFailDoc m where
     failDoc :: Doc -> m a
 
 na :: MonadFailDoc m => Doc -> m a
 na message = failDoc ("N/A:" <+> message)
 
+instance MonadFail Identity where
+    fail = error
 instance MonadFailDoc Identity where
     failDoc = Control.Monad.fail . show
 
@@ -397,10 +399,10 @@ instance MonadFailDoc m => MonadFailDoc (IdentityT m) where
 instance (Functor m, Monad m) => MonadFailDoc (MaybeT m) where
     failDoc = const $ MaybeT $ return Nothing
 
-instance (Functor m, Monad m) => MonadFailDoc (ExceptT m) where
+instance (MonadFailDoc m) => MonadFailDoc (ExceptT m) where
     failDoc = ExceptT . return . Left
 
-instance (Functor m, Monad m, MonadFailDoc m) => MonadFailDoc (StateT st m) where
+instance (MonadFailDoc m) => MonadFailDoc (StateT st m) where
     failDoc = lift . failDoc
 
 instance (MonadFailDoc m, Monoid w) => MonadFailDoc (WriterT w m) where
@@ -409,6 +411,8 @@ instance (MonadFailDoc m, Monoid w) => MonadFailDoc (WriterT w m) where
 instance MonadFailDoc m => MonadFailDoc (ReaderT r m) where
     failDoc = lift . failDoc
 
+instance MonadFail Gen where
+    fail = error
 instance MonadFailDoc Gen where
     failDoc = Control.Monad.fail . show
 

--- a/src/Conjure/Process/Boost.hs
+++ b/src/Conjure/Process/Boost.hs
@@ -427,7 +427,7 @@ totalInjectiveIsBijective _ ((_, dom), _)
          _ -> return mempty
 
 -- | If a function is defined for all values in its domain, then it is total.
-definedForAllIsTotal :: ( MonadLog m, ?typeCheckerMode :: TypeCheckerMode)
+definedForAllIsTotal :: (MonadFailDoc m, MonadLog m, ?typeCheckerMode :: TypeCheckerMode)
                      => Model
                      -> (FindVar, [ExpressionZ])
                      -> m ([AttrPair], ToAddToRem)
@@ -458,7 +458,7 @@ definedForAllIsTotal _ ((n, dom), cs)
 -- | If all distinct inputs to a function have distinct results, then it is injective.
 --   It will also be total if there are no conditions other than the disequality between
 --   the two inputs.
-diffArgResultIsInjective :: ( MonadLog m, ?typeCheckerMode :: TypeCheckerMode)
+diffArgResultIsInjective :: (MonadFailDoc m, MonadLog m, ?typeCheckerMode :: TypeCheckerMode)
                          => Model
                          -> (FindVar, [ExpressionZ])
                          -> m ([AttrPair], ToAddToRem)
@@ -480,7 +480,7 @@ diffArgResultIsInjective _ ((n, DomainFunction _ (FunctionAttr _ _ ject) from _)
 diffArgResultIsInjective _ _ = return mempty
 
 -- | Set a size attribute on a variable.
-varSize :: ( MonadLog m)
+varSize :: (MonadFailDoc m, MonadLog m)
         => Model
         -> (FindVar, [ExpressionZ])
         -> m ([AttrPair], ToAddToRem)
@@ -501,7 +501,7 @@ cardinalityOf _ = Nothing
 
 
 -- | Set the minimum size of a set based on it being a superset of another.
-setSize :: ( MonadLog m, NameGen m, ?typeCheckerMode :: TypeCheckerMode)
+setSize :: (MonadFailDoc m, MonadLog m, NameGen m, ?typeCheckerMode :: TypeCheckerMode)
         => Model
         -> (FindVar, [ExpressionZ])
         -> m ([AttrPair], ToAddToRem)
@@ -584,7 +584,7 @@ setSize _ ((n, DomainSet{}), cs)
 setSize _ _ = return mempty
 
 -- | The maxSize, and minOccur attributes of an mset affect its maxOccur and minSize attributes.
-mSetSizeOccur :: ( MonadLog m)
+mSetSizeOccur :: (MonadFailDoc m, MonadLog m)
               => Model
               -> (FindVar, [ExpressionZ])
               -> m ([AttrPair], ToAddToRem)
@@ -610,7 +610,7 @@ mSetSizeOccur _ ((_, d), _)
          _ -> return mempty
 
 -- | Infer multiset occurrence attributes from constraints.
-mSetOccur :: ( MonadLog m)
+mSetOccur :: (MonadFailDoc m, MonadLog m)
           => Model
           -> (FindVar, [ExpressionZ])
           -> m ([AttrPair], ToAddToRem)
@@ -654,7 +654,7 @@ mSetOccur _ ((n, DomainMSet _ _ d), cs)
 mSetOccur _ _ = return mempty
 
 -- | Mark a partition regular if there is a constraint on its parts constraining them to be of equal size.
-partRegular :: ( MonadLog m, ?typeCheckerMode :: TypeCheckerMode)
+partRegular :: (MonadFailDoc m, MonadLog m, ?typeCheckerMode :: TypeCheckerMode)
             => Model
             -> (FindVar, [ExpressionZ])
             -> m ([AttrPair], ToAddToRem)
@@ -676,7 +676,7 @@ partRegular _ _ = return mempty
 
 
 -- | Convert constraints acting on the number of parts in a partition to an attribute.
-numPartsToAttr :: ( MonadLog m)
+numPartsToAttr :: (MonadFailDoc m, MonadLog m)
                => Model
                -> (FindVar, [ExpressionZ])
                -> m ([AttrPair], ToAddToRem)
@@ -697,7 +697,7 @@ numPartsToAttr _ ((n, DomainPartition{}), cs) = do
 numPartsToAttr _ _ = return mempty
 
 -- | Convert constraints acting on the sizes of parts in a partition to an attribute.
-partSizeToAttr :: ( MonadLog m)
+partSizeToAttr :: (MonadFailDoc m, MonadLog m)
                => Model
                -> (FindVar, [ExpressionZ])
                -> m ([AttrPair], ToAddToRem)
@@ -734,7 +734,7 @@ partSizeToAttr _ _ = return mempty
 
 -- | Equate the range of a function to a set of the former is a subset of the latter
 --   and all values in the set are results of the function.
-funcRangeEqSet :: ( MonadLog m)
+funcRangeEqSet :: (MonadFailDoc m, MonadLog m)
                => Model
                -> (FindVar, [ExpressionZ])
                -> m ([AttrPair], ToAddToRem)
@@ -770,7 +770,7 @@ funcRangeEqSet _ _ = return mempty
 
 -- | An (in)equality in a forAll implies that the (in)equality also applies to
 --   the sums of both terms.
-forAllIneqToIneqSum :: ( MonadLog m, NameGen m, ?typeCheckerMode :: TypeCheckerMode)
+forAllIneqToIneqSum :: (MonadFailDoc m, MonadLog m, NameGen m, ?typeCheckerMode :: TypeCheckerMode)
                     => Model
                     -> (FindVar, [ExpressionZ])
                     -> m ([AttrPair], ToAddToRem)
@@ -814,7 +814,7 @@ forAllIneqToIneqSum _ (_, cs) = do
     mkConstraint _ = Nothing
 
 -- | Iterate slightly faster over a domain if generating two distinct variables.
-fasterIteration :: ( MonadFailDoc m,MonadIO m, MonadLog m, ?typeCheckerMode :: TypeCheckerMode)
+fasterIteration :: (MonadFailDoc m, MonadFailDoc m,MonadIO m, MonadLog m, ?typeCheckerMode :: TypeCheckerMode)
                 => Model
                 -> (FindVar, [ExpressionZ])
                 -> m ([AttrPair], ToAddToRem)
@@ -899,7 +899,7 @@ ferret path = sh (run "symmetry_detect" [ "--json", path ]) `catch`
               (\(_ :: SomeException) -> return "{}")
 
 -- | Change the type of a multiset with `maxOccur 1` to set.
-mSetToSet :: ( MonadLog m)
+mSetToSet :: (MonadFailDoc m, MonadLog m)
           => Model
           -> (FindVar, [ExpressionZ])
           -> m (Domain () Expression, ToAddToRem)

--- a/src/Conjure/Process/DealWithCuts.hs
+++ b/src/Conjure/Process/DealWithCuts.hs
@@ -11,7 +11,7 @@ import Conjure.Language.ModelStats ( finds )
 
 
 dealWithCuts
-    :: (MonadFail m, NameGen m, MonadUserError m)
+    :: ( NameGen m, MonadUserError m)
     => Model
     -> m Model
 dealWithCuts m = do

--- a/src/Conjure/Process/DealWithCuts.hs
+++ b/src/Conjure/Process/DealWithCuts.hs
@@ -11,7 +11,7 @@ import Conjure.Language.ModelStats ( finds )
 
 
 dealWithCuts
-    :: ( NameGen m, MonadUserError m)
+    :: (MonadFailDoc m, NameGen m, MonadUserError m)
     => Model
     -> m Model
 dealWithCuts m = do

--- a/src/Conjure/Process/Enumerate.hs
+++ b/src/Conjure/Process/Enumerate.hs
@@ -61,16 +61,16 @@ instance Monad EnumerateDomainNoIO where
     TriedIO    >>= _ = TriedIO
     Done x     >>= f = f x
 
-instance MonadFail EnumerateDomainNoIO where
-    fail = Failed
+instance MonadFailDoc EnumerateDomainNoIO where
+    failDoc = Failed
 
 instance MonadUserError EnumerateDomainNoIO where
     userErr docs = Failed (vcat $ "User error:" : docs)
 
 instance NameGen EnumerateDomainNoIO where
-    nextName _ = fail "nextName{EnumerateDomainNoIO}"
-    exportNameGenState = fail "exportNameGenState{EnumerateDomainNoIO}"
-    importNameGenState _ = fail "importNameGenState{EnumerateDomainNoIO}"
+    nextName _ = failDoc "nextName{EnumerateDomainNoIO}"
+    exportNameGenState = failDoc "exportNameGenState{EnumerateDomainNoIO}"
+    importNameGenState _ = failDoc "importNameGenState{EnumerateDomainNoIO}"
 
 instance EnumerateDomain EnumerateDomainNoIO where liftIO' _ = TriedIO
 
@@ -83,7 +83,7 @@ minionTimelimit = 60
 savilerowTimelimit :: Int
 savilerowTimelimit = 60 * 1000
 
-enumerateDomain :: (MonadFail m, EnumerateDomain m) => Domain () Constant -> m [Constant]
+enumerateDomain :: (MonadFailDoc m, EnumerateDomain m) => Domain () Constant -> m [Constant]
 
 enumerateDomain d | not (null [ () | ConstantUndefined{} <- universeBi d ]) =
     bug $ vcat [ "called enumerateDomain with a domain that has undefinedness values in it."
@@ -91,7 +91,7 @@ enumerateDomain d | not (null [ () | ConstantUndefined{} <- universeBi d ]) =
                ]
 
 enumerateDomain DomainBool = return [ConstantBool False, ConstantBool True]
-enumerateDomain (DomainInt _ []) = fail "enumerateDomain: infinite domain"
+enumerateDomain (DomainInt _ []) = failDoc "enumerateDomain: infinite domain"
 enumerateDomain (DomainInt _ rs) = concatMapM enumerateRange rs
 enumerateDomain (DomainUnnamed _ (ConstantInt t n)) = return (map (ConstantInt t) [1..n])
 enumerateDomain (DomainEnum _dName (Just rs) _mp) = concatMapM enumerateRange rs
@@ -188,7 +188,7 @@ enumerateDomain d = liftIO' $ withSystemTempDirectory ("conjure-enumerateDomain-
                 | decl <- decls ]
         if null errs
             then return enumeration
-            else fail $ vcat $ "enumerateDomain, not Constants!"
+            else failDoc $ vcat $ "enumerateDomain, not Constants!"
                              : ("When working on domain:" <++> pretty d)
                              :  map pretty errs
                              ++ map (pretty . show) errs
@@ -197,15 +197,15 @@ enumerateDomain d = liftIO' $ withSystemTempDirectory ("conjure-enumerateDomain-
     return enumeration
 
 
-enumerateRange :: MonadFail m => Range Constant -> m [Constant]
+enumerateRange :: MonadFailDoc m => Range Constant -> m [Constant]
 enumerateRange (RangeSingle x) = return [x]
 enumerateRange (RangeBounded (ConstantInt t x) (ConstantInt _ y)) = return $ ConstantInt t <$> [x..y]
-enumerateRange RangeBounded{} = fail "enumerateRange RangeBounded"
-enumerateRange RangeOpen{} = fail "enumerateRange RangeOpen"
-enumerateRange RangeLowerBounded{} = fail "enumerateRange RangeLowerBounded"
-enumerateRange RangeUpperBounded{} = fail "enumerateRange RangeUpperBounded"
+enumerateRange RangeBounded{} = failDoc "enumerateRange RangeBounded"
+enumerateRange RangeOpen{} = failDoc "enumerateRange RangeOpen"
+enumerateRange RangeLowerBounded{} = failDoc "enumerateRange RangeLowerBounded"
+enumerateRange RangeUpperBounded{} = failDoc "enumerateRange RangeUpperBounded"
 
-enumerateInConstant :: MonadFail m => Constant -> m [Constant]
+enumerateInConstant :: MonadFailDoc m => Constant -> m [Constant]
 enumerateInConstant constant = case constant of
     ConstantAbstract (AbsLitMatrix _  xs) -> return xs
     ConstantAbstract (AbsLitSet       xs) -> return xs
@@ -218,6 +218,6 @@ enumerateInConstant constant = case constant of
     ConstantAbstract (AbsLitRelation  xs) -> return $ map (ConstantAbstract . AbsLitTuple) xs
     ConstantAbstract (AbsLitPartition xs) -> return $ map (ConstantAbstract . AbsLitSet) xs
     TypedConstant c _                     -> enumerateInConstant c
-    _ -> fail $ vcat [ "enumerateInConstant"
+    _ -> failDoc $ vcat [ "enumerateInConstant"
                      , "constant:" <+> pretty constant
                      ]

--- a/src/Conjure/Process/Enumerate.hs
+++ b/src/Conjure/Process/Enumerate.hs
@@ -63,6 +63,8 @@ instance Monad EnumerateDomainNoIO where
 
 instance MonadFailDoc EnumerateDomainNoIO where
     failDoc = Failed
+instance MonadFail EnumerateDomainNoIO where
+    fail = Failed . stringToDoc 
 
 instance MonadUserError EnumerateDomainNoIO where
     userErr docs = Failed (vcat $ "User error:" : docs)

--- a/src/Conjure/Process/Enums.hs
+++ b/src/Conjure/Process/Enums.hs
@@ -28,7 +28,7 @@ import qualified Data.HashMap.Strict as M
 -- | The argument is a model before nameResolution.
 --   Only intended to work on problem specifications.
 removeEnumsFromModel ::
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadLog m =>
     MonadUserError m =>
     Model -> m Model
@@ -85,7 +85,7 @@ removeEnumsFromModel =
                     = return (fromIntWithTag i (TagEnum ename))
                 onX p = return p
 
-                onD :: MonadFail m => Domain () Expression -> m (Domain () Expression)
+                onD :: MonadFailDoc m => Domain () Expression -> m (Domain () Expression)
                 onD (DomainEnum nm@(Name nmText) (Just ranges) _)
                     | Just _ <- lookup nm enumDomainNames
                     = DomainInt (TagEnum nmText) <$> mapM (mapM (nameToX nameToIntMapping)) ranges
@@ -148,7 +148,7 @@ removeEnumsFromModel =
 
 
 removeEnumsFromParam
-    :: (MonadFail m, MonadUserError m)
+    :: (MonadFailDoc m, MonadUserError m)
     => Model -> Model -> m (Model, Model)
 removeEnumsFromParam model param = do
     let allStatements = map (False,) (map Declaration (miEnumLettings (mInfo model)))
@@ -185,7 +185,7 @@ removeEnumsFromParam model param = do
             = return (fromIntWithTag i (TagEnum ename))
         onX p = return p
 
-        onD :: MonadFail m => Domain () Expression -> m (Domain () Expression)
+        onD :: MonadFailDoc m => Domain () Expression -> m (Domain () Expression)
         onD (DomainEnum nm@(Name nmText) (Just ranges) _)
             | Just _ <- M.lookup nm enumDomainNames
             = DomainInt (TagEnum nmText) <$> mapM (mapM (nameToX nameToIntMapping)) ranges
@@ -289,9 +289,9 @@ addEnumsAndUnnamedsBack unnameds ctxt = helper
                                                              ])
 
 -- first Name is the value, the second Name is the name of the enum domain
-nameToX :: MonadFail m => M.HashMap Name (Name, Integer) -> Expression -> m Expression
+nameToX :: MonadFailDoc m => M.HashMap Name (Name, Integer) -> Expression -> m Expression
 nameToX nameToIntMapping (Reference nm _) = case M.lookup nm nameToIntMapping of
-    Nothing -> fail (pretty nm <+> "is used in a domain, but it isn't a member of the enum domain.")
+    Nothing -> failDoc (pretty nm <+> "is used in a domain, but it isn't a member of the enum domain.")
     Just (Name ename, i)  -> return (fromIntWithTag i (TagEnum ename))
     Just (ename, i) -> bug $ "nameToX, nm:" <+> vcat [pretty (show ename), pretty i]
 nameToX _ x = return x

--- a/src/Conjure/Process/FiniteGivens.hs
+++ b/src/Conjure/Process/FiniteGivens.hs
@@ -21,6 +21,8 @@ import Conjure.Process.Enumerate ( EnumerateDomain )
 --   this transformation introduces extra given ints to make them finite.
 --   the values for the extra givens will be computed during translate-solution
 finiteGivens ::
+    MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     MonadLog m =>
     MonadUserError m =>
@@ -44,6 +46,8 @@ finiteGivens m = flip evalStateT 1 $ do
 
 
 finiteGivensParam ::
+    MonadFail  m =>
+    MonadFailDoc  m =>
     NameGen m =>
     MonadLog m =>
     MonadUserError m =>
@@ -101,6 +105,8 @@ finiteGivensParam eprimeModel essenceParam additionalLettings = flip evalStateT 
 --   for example, this means adding a size attribute at the outer-most level
 --   and adding a maxSize attribute at the inner levels.
 mkFinite ::
+    MonadFail m =>
+    MonadFailDoc m =>
     MonadState Int m =>
     NameGen m =>
     MonadLog m =>
@@ -126,6 +132,8 @@ mkFinite d = return (d, [], const (return []))
 
 
 mkFiniteOutermost ::
+    MonadFail m =>
+    MonadFailDoc m =>
     MonadState Int m =>
     NameGen m =>
     MonadLog m =>
@@ -356,6 +364,8 @@ mkFiniteOutermost d = return (d, [], const (return []))
 
 
 mkFiniteInner ::
+    MonadFail m =>
+    MonadFailDoc m =>
     MonadState Int m =>
     NameGen m =>
     MonadLog m =>

--- a/src/Conjure/Process/FiniteGivens.hs
+++ b/src/Conjure/Process/FiniteGivens.hs
@@ -21,7 +21,6 @@ import Conjure.Process.Enumerate ( EnumerateDomain )
 --   this transformation introduces extra given ints to make them finite.
 --   the values for the extra givens will be computed during translate-solution
 finiteGivens ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     MonadLog m =>
@@ -46,7 +45,6 @@ finiteGivens m = flip evalStateT 1 $ do
 
 
 finiteGivensParam ::
-    MonadFail  m =>
     MonadFailDoc  m =>
     NameGen m =>
     MonadLog m =>
@@ -105,7 +103,6 @@ finiteGivensParam eprimeModel essenceParam additionalLettings = flip evalStateT 
 --   for example, this means adding a size attribute at the outer-most level
 --   and adding a maxSize attribute at the inner levels.
 mkFinite ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadState Int m =>
     NameGen m =>
@@ -132,7 +129,6 @@ mkFinite d = return (d, [], const (return []))
 
 
 mkFiniteOutermost ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadState Int m =>
     NameGen m =>
@@ -364,7 +360,6 @@ mkFiniteOutermost d = return (d, [], const (return []))
 
 
 mkFiniteInner ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadState Int m =>
     NameGen m =>

--- a/src/Conjure/Process/InferAttributes.hs
+++ b/src/Conjure/Process/InferAttributes.hs
@@ -12,14 +12,14 @@ import Conjure.Language.NameResolution ( resolveX, resolveD )
 
 
 inferAttributes ::
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadUserError m =>
     NameGen m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
     Model -> m Model
 inferAttributes = flip evalStateT [] . go where
     go ::
-        MonadFail m =>
+        MonadFailDoc m =>
         MonadUserError m =>
         NameGen m =>
         MonadState [(Name, ReferenceTo)] m =>
@@ -48,7 +48,7 @@ inferAttributes = flip evalStateT [] . go where
         transformBiM inferAttributesD m
 
 inferAttributesD ::
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadUserError m =>
     NameGen m =>
     MonadState [(Name, ReferenceTo)] m =>

--- a/src/Conjure/Process/LettingsForComplexInDoms.hs
+++ b/src/Conjure/Process/LettingsForComplexInDoms.hs
@@ -42,7 +42,7 @@ lettingsForComplexInDoms m = do
 
 
 -- | inline letting domains for declarations, before saving the original domain in the logs
-inlineLettingDomainsForDecls :: MonadFail m => Model -> m Model
+inlineLettingDomainsForDecls :: MonadFailDoc m => Model -> m Model
 inlineLettingDomainsForDecls m = do
     let
         f (DomainReference name Nothing) = do
@@ -51,7 +51,7 @@ inlineLettingDomainsForDecls m = do
                 Just d -> transformM f d
                 _ -> if name `elem` unnameds
                         then return (DomainReference name Nothing)
-                        else fail $ vcat
+                        else failDoc $ vcat
                                 $ ("No value for:" <+> pretty name)
                                 : "Bindings in context:"
                                 : prettyContext ctxt

--- a/src/Conjure/Process/LettingsForComplexInDoms.hs
+++ b/src/Conjure/Process/LettingsForComplexInDoms.hs
@@ -16,7 +16,7 @@ import Conjure.Language.Pretty
 --   however, this transformation (as part of `Conjure.UI.Model.prologue`) cleans this up by introducing
 --   extra letting statements.
 lettingsForComplexInDoms ::
-    MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     Model -> m Model
 lettingsForComplexInDoms m = do

--- a/src/Conjure/Process/Sanity.hs
+++ b/src/Conjure/Process/Sanity.hs
@@ -8,13 +8,13 @@ import Conjure.Language
 import Conjure.Language.CategoryOf
 
 
-sanityChecks :: (MonadFail m, MonadUserError m) => Model -> m Model
+sanityChecks :: (MonadFailDoc m, MonadUserError m) => Model -> m Model
 sanityChecks model = do
     let
         recordErr :: MonadWriter [Doc] m => [Doc] -> m ()
         recordErr = tell . return . vcat
 
-        check :: (MonadFail m, MonadWriter [Doc] m) => Model -> m Model
+        check :: (MonadFailDoc m, MonadWriter [Doc] m) => Model -> m Model
         check m = do
             upToOneObjective m
             upToOneHeuristic m
@@ -118,7 +118,7 @@ sanityChecks model = do
         -- check for partition literals
         --     the parts have to be disjoint
         -- TODO: Generate where clauses for when they contain parameters.
-        checkLit :: MonadFail m => Expression -> m Expression
+        checkLit :: MonadFailDoc m => Expression -> m Expression
         checkLit lit = case lit of
             AbstractLiteral (AbsLitSet xs) -> do
                 let ys = fromList xs

--- a/src/Conjure/Process/ValidateConstantForDomain.hs
+++ b/src/Conjure/Process/ValidateConstantForDomain.hs
@@ -18,7 +18,6 @@ import Data.Set as S ( size, size, toList )
 
 validateConstantForDomain ::
     forall m r .
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -54,7 +53,7 @@ validateConstantForDomain name
     c@(viewConstantIntWithTag -> Just (cTag, _))
     d@(DomainEnum _ (Just ranges) (Just mp)) = nested c d $ do
         let
-            -- lu :: MonadFail m => Name -> m Constant
+            -- lu :: MonadFailDoc m =>  Name -> m Constant
             lu (ConstantEnum _ _ nm) =
                 case lookup nm mp of
                     Nothing -> failDoc $ "No value for:" <+> pretty nm
@@ -62,7 +61,7 @@ validateConstantForDomain name
             lu (ConstantInt t v) = return (ConstantInt t v)
             lu x = failDoc $ "validateConstantForDomain.lu" <+> pretty x
 
-            -- lu2 :: MonadFail m => Range Name -> m (Range Constant)
+            -- lu2 :: MonadFailDoc m =>  Range Name -> m (Range Constant)
             lu2 = mapM lu
 
         rs <- mapM lu2 ranges

--- a/src/Conjure/Process/ValidateConstantForDomain.hs-boot
+++ b/src/Conjure/Process/ValidateConstantForDomain.hs-boot
@@ -7,7 +7,6 @@ import Conjure.Process.Enumerate ( EnumerateDomain )
 
 validateConstantForDomain ::
     forall m r .
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>

--- a/src/Conjure/Process/ValidateConstantForDomain.hs-boot
+++ b/src/Conjure/Process/ValidateConstantForDomain.hs-boot
@@ -8,6 +8,7 @@ import Conjure.Process.Enumerate ( EnumerateDomain )
 validateConstantForDomain ::
     forall m r .
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>

--- a/src/Conjure/Representations.hs
+++ b/src/Conjure/Representations.hs
@@ -22,7 +22,6 @@ import Conjure.Representations.Combined
 
 -- | Refine (down) an expression (X), one level (1).
 downX1 ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -54,7 +53,6 @@ downX x = do
 
 
 onConstant ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -77,7 +75,6 @@ onConstant (TypedConstant c _) = onConstant c
 onConstant x = bug ("downX1.onConstant:" <++> pretty (show x))
 
 onAbstractLiteral ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -98,7 +95,6 @@ onAbstractLiteral (AbsLitMatrix index xs) = do
 onAbstractLiteral x = bug ("downX1.onAbstractLiteral:" <++> pretty (show x))
 
 onReference ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -114,7 +110,6 @@ onReference nm refTo =
         VariantField{}            -> failDoc ("downX1.onReference.VariantField:"    <++> pretty (show nm))
 
 onOp ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -142,7 +137,6 @@ onOp op = failDoc ("downX1.onOp:" <++> pretty op)
 
 
 symmetryOrdering ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>

--- a/src/Conjure/Representations.hs
+++ b/src/Conjure/Representations.hs
@@ -23,6 +23,7 @@ import Conjure.Representations.Combined
 -- | Refine (down) an expression (X), one level (1).
 downX1 ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -34,7 +35,7 @@ downX1 (Op x) = onOp x
 downX1 (Comprehension body stmts) = do
     xs <- downX1 body
     return [Comprehension x stmts | x <- xs]
-downX1 x@WithLocals{} = fail ("downX1:" <++> pretty (show x))
+downX1 x@WithLocals{} = failDoc ("downX1:" <++> pretty (show x))
 downX1 x = bug ("downX1:" <++> pretty (show x))
 
 
@@ -54,6 +55,7 @@ downX x = do
 
 onConstant ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -76,6 +78,7 @@ onConstant x = bug ("downX1.onConstant:" <++> pretty (show x))
 
 onAbstractLiteral ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -96,6 +99,7 @@ onAbstractLiteral x = bug ("downX1.onAbstractLiteral:" <++> pretty (show x))
 
 onReference ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -103,14 +107,15 @@ onReference ::
 onReference nm refTo =
     case refTo of
         Alias x                   -> downX1 x
-        InComprehension{}         -> fail ("downX1.onReference.InComprehension:" <++> pretty (show nm))
-        DeclNoRepr{}              -> fail ("downX1.onReference.DeclNoRepr:"      <++> pretty (show nm))
+        InComprehension{}         -> failDoc ("downX1.onReference.InComprehension:" <++> pretty (show nm))
+        DeclNoRepr{}              -> failDoc ("downX1.onReference.DeclNoRepr:"      <++> pretty (show nm))
         DeclHasRepr forg _ domain -> downToX1 forg nm domain
-        RecordField{}             -> fail ("downX1.onReference.RecordField:"     <++> pretty (show nm))
-        VariantField{}            -> fail ("downX1.onReference.VariantField:"    <++> pretty (show nm))
+        RecordField{}             -> failDoc ("downX1.onReference.RecordField:"     <++> pretty (show nm))
+        VariantField{}            -> failDoc ("downX1.onReference.VariantField:"    <++> pretty (show nm))
 
 onOp ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -120,7 +125,7 @@ onOp p@(MkOpIndexing (OpIndexing m i)) = do
     case ty of
         TypeMatrix{} -> return ()
         TypeList{}   -> return ()
-        _ -> fail $ "[onOp, not a TypeMatrix or TypeList]" <+> vcat [pretty ty, pretty p]
+        _ -> failDoc $ "[onOp, not a TypeMatrix or TypeList]" <+> vcat [pretty ty, pretty p]
     xs <- downX1 m
     let iIndexed x = Op (MkOpIndexing (OpIndexing x i))
     return (map iIndexed xs)
@@ -132,12 +137,13 @@ onOp (MkOpImage (OpImage (match functionLiteral -> Just (_, xs)) a)) | length xs
     let outs = map (zip keys) (transpose vals)
     return [ Op $ MkOpImage $ OpImage (AbstractLiteral (AbsLitFunction out)) a
            | out <- outs ]
-onOp op = fail ("downX1.onOp:" <++> pretty op)
+onOp op = failDoc ("downX1.onOp:" <++> pretty op)
 
 
 
 symmetryOrdering ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>

--- a/src/Conjure/Representations/Combined.hs
+++ b/src/Conjure/Representations/Combined.hs
@@ -45,7 +45,6 @@ import Conjure.Representations.Partition.PartitionAsSet
 -- | Refine (down) a domain, outputting refinement expressions (X) one level (1).
 --   The domain is allowed to be at the class level.
 downToX1 ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -56,7 +55,6 @@ downToX1 forg name domain = rDownToX (dispatch domain) forg name domain
 -- | Refine (down) a domain (D), one level (1).
 --   The domain is allowed to be at the class level.
 downD1 ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -67,7 +65,6 @@ downD1 (name, domain) = rDownD (dispatch domain) (name, domain)
 -- | Refine (down) a domain, together with a constant (C), one level (1).
 --   The domain has to be fully instantiated.
 downC1 ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -80,7 +77,6 @@ downC1 (name, domain, constant) = rDownC (dispatch domain) (name, domain, consta
 --   The high level domain (i.e. the target domain) has to be given.
 --   The domain has to be fully instantiated.
 up1 ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -92,7 +88,6 @@ up1 (name, domain) ctxt = rUp (dispatch domain) ctxt (name, domain)
 -- | Refine (down) a domain (D), all the way.
 --   The domain is allowed to be at the class level.
 downD ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -107,7 +102,6 @@ downD inp@(_, domain) = do
 -- | Refine (down) a domain, together with a constant (C), all the way.
 --   The domain has to be fully instantiated.
 downC ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -125,7 +119,6 @@ downC inp0 = do
 --   The high level domain (i.e. the target domain) has to be given.
 --   The domain has to be fully instantiated.
 up ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -155,7 +148,6 @@ up ctxt (name, highDomain) = do
 
 -- | ...
 symmetryOrderingDispatch ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -174,7 +166,6 @@ symmetryOrderingDispatch downX1 inp domain =
 -- | Combine all known representations into one.
 --   Dispatch into the actual implementation of the representation depending on the provided domain.
 dispatch ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -235,7 +226,6 @@ type AllRepresentations m = [[Representation m]]
 
 -- | No levels!
 reprsStandardOrderNoLevels ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -248,7 +238,6 @@ reprsStandardOrderNoLevels = [concat reprsStandardOrder]
 --   As a crude measure, implementing levels here.
 --   We shouldn't have levels between representations in the long run.
 reprsStandardOrder ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -273,7 +262,6 @@ reprsStandardOrder =
 
 -- | Sparser representations are to be preferred for parameters.
 reprsSparseOrder ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -328,7 +316,6 @@ reprOptions reprs (expandDomainReference -> domain) = go reprs
 --   Makes recursive calls to generate the complete structural constraints.
 --   Takes in a function to refine inner guys.
 getStructurals ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>

--- a/src/Conjure/Representations/Combined.hs
+++ b/src/Conjure/Representations/Combined.hs
@@ -46,6 +46,7 @@ import Conjure.Representations.Partition.PartitionAsSet
 --   The domain is allowed to be at the class level.
 downToX1 ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -56,6 +57,7 @@ downToX1 forg name domain = rDownToX (dispatch domain) forg name domain
 --   The domain is allowed to be at the class level.
 downD1 ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -66,6 +68,7 @@ downD1 (name, domain) = rDownD (dispatch domain) (name, domain)
 --   The domain has to be fully instantiated.
 downC1 ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -78,6 +81,7 @@ downC1 (name, domain, constant) = rDownC (dispatch domain) (name, domain, consta
 --   The domain has to be fully instantiated.
 up1 ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -89,6 +93,7 @@ up1 (name, domain) ctxt = rUp (dispatch domain) ctxt (name, domain)
 --   The domain is allowed to be at the class level.
 downD ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -103,6 +108,7 @@ downD inp@(_, domain) = do
 --   The domain has to be fully instantiated.
 downC ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -120,6 +126,7 @@ downC inp0 = do
 --   The domain has to be fully instantiated.
 up ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -131,7 +138,7 @@ up ctxt (name, highDomain) = do
     case toDescend' of
         Nothing ->
             case lookup name ctxt of
-                Nothing -> fail $ vcat
+                Nothing -> failDoc $ vcat
                     $ ("No value for:" <+> pretty name)
                     : "Bindings in context:"
                     : prettyContext ctxt
@@ -149,6 +156,7 @@ up ctxt (name, highDomain) = do
 -- | ...
 symmetryOrderingDispatch ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -167,6 +175,7 @@ symmetryOrderingDispatch downX1 inp domain =
 --   Dispatch into the actual implementation of the representation depending on the provided domain.
 dispatch ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     Pretty x =>
@@ -227,6 +236,7 @@ type AllRepresentations m = [[Representation m]]
 -- | No levels!
 reprsStandardOrderNoLevels ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -239,6 +249,7 @@ reprsStandardOrderNoLevels = [concat reprsStandardOrder]
 --   We shouldn't have levels between representations in the long run.
 reprsStandardOrder ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -263,6 +274,7 @@ reprsStandardOrder =
 -- | Sparser representations are to be preferred for parameters.
 reprsSparseOrder ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -317,6 +329,7 @@ reprOptions reprs (expandDomainReference -> domain) = go reprs
 --   Takes in a function to refine inner guys.
 getStructurals ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>

--- a/src/Conjure/Representations/Function/Function1D.hs
+++ b/src/Conjure/Representations/Function/Function1D.hs
@@ -22,7 +22,7 @@ import Conjure.Representations.Common
 import qualified Data.HashMap.Strict as M
 
 
-function1D :: forall m . (MonadFailDoc m,MonadFail m, NameGen m, ?typeCheckerMode :: TypeCheckerMode) => Representation m
+function1D :: forall m . (MonadFailDoc m, NameGen m, ?typeCheckerMode :: TypeCheckerMode) => Representation m
 function1D = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/Function/Function1D.hs
+++ b/src/Conjure/Representations/Function/Function1D.hs
@@ -181,7 +181,7 @@ function1D = Representation chck downD structuralCons downC up symmetryOrdering
                                 ]
         up _ _ = na "{up} Function1D"
 
-        symmetryOrdering ::TypeOf_SymmetryOrdering m
+        symmetryOrdering :: TypeOf_SymmetryOrdering m
         symmetryOrdering innerSO downX1 inp domain = do
             [inner] <- downX1 inp
             Just [(_, innerDomain)] <- downD ("SO", domain)

--- a/src/Conjure/Representations/Function/Function1D.hs
+++ b/src/Conjure/Representations/Function/Function1D.hs
@@ -22,7 +22,7 @@ import Conjure.Representations.Common
 import qualified Data.HashMap.Strict as M
 
 
-function1D :: forall m . (MonadFail m, NameGen m, ?typeCheckerMode :: TypeCheckerMode) => Representation m
+function1D :: forall m . (MonadFailDoc m, NameGen m, ?typeCheckerMode :: TypeCheckerMode) => Representation m
 function1D = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -142,7 +142,7 @@ function1D = Representation chck downD structuralCons downC up symmetryOrdering
                 [ val
                 | fr <- froms
                 , let val = case M.lookup fr vals of
-                                Nothing -> fail $ vcat [ "No value for" <+> pretty fr
+                                Nothing -> failDoc $ vcat [ "No value for" <+> pretty fr
                                                        , "In:" <+> pretty (AbsLitFunction vals_)
                                                        ]
                                 Just v  -> return v
@@ -159,7 +159,7 @@ function1D = Representation chck downD structuralCons downC up symmetryOrdering
                                 (FunctionAttr _ PartialityAttr_Total _)
                                 innerDomainFr _)) =
             case lookup (outName domain name) ctxt of
-                Nothing -> fail $ vcat $
+                Nothing -> failDoc $ vcat $
                     [ "(in Function1D up)"
                     , "No value for:" <+> pretty (outName domain name)
                     , "When working on:" <+> pretty name
@@ -173,7 +173,7 @@ function1D = Representation chck downD structuralCons downC up symmetryOrdering
                             return ( name
                                    , ConstantAbstract $ AbsLitFunction $ zip froms vals
                                    )
-                        _ -> fail $ vcat
+                        _ -> failDoc $ vcat
                                 [ "Expecting a matrix literal for:" <+> pretty (outName domain name)
                                 , "But got:" <+> pretty constant
                                 , "When working on:" <+> pretty name
@@ -181,16 +181,20 @@ function1D = Representation chck downD structuralCons downC up symmetryOrdering
                                 ]
         up _ _ = na "{up} Function1D"
 
-        symmetryOrdering :: TypeOf_SymmetryOrdering m
+        symmetryOrdering ::TypeOf_SymmetryOrdering m
         symmetryOrdering innerSO downX1 inp domain = do
-            [inner] <- downX1 inp
-            Just [(_, innerDomain)] <- downD ("SO", domain)
-            innerSO downX1 inner innerDomain
+            i <- downX1 inp
+            d <- downD ("SO", domain)
+            case (i,d) of 
+                ([inner],Just [(_,innerDomain)]) -> innerSO downX1 inner innerDomain
+                _ -> na "Pattern match error{symetryOrderingFunc1D}"
+            
 
 
-domainValues :: (MonadFail m, Pretty r) => Domain r Constant -> m [Constant]
+domainValues :: (MonadFailDoc m, Pretty r) => Domain r Constant -> m [Constant]
 domainValues dom =
     case dom of
         DomainBool -> return [ConstantBool False, ConstantBool True]
         DomainInt t rs -> map (ConstantInt t) <$> valuesInIntDomain rs
-        _ -> fail ("domainValues, not supported:" <+> pretty dom)
+        _ -> failDoc ("domainValues, not supported:" <+> pretty dom)
+

--- a/src/Conjure/Representations/Function/Function1D.hs
+++ b/src/Conjure/Representations/Function/Function1D.hs
@@ -22,7 +22,7 @@ import Conjure.Representations.Common
 import qualified Data.HashMap.Strict as M
 
 
-function1D :: forall m . (MonadFailDoc m, NameGen m, ?typeCheckerMode :: TypeCheckerMode) => Representation m
+function1D :: forall m . (MonadFailDoc m,MonadFail m, NameGen m, ?typeCheckerMode :: TypeCheckerMode) => Representation m
 function1D = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -183,11 +183,9 @@ function1D = Representation chck downD structuralCons downC up symmetryOrdering
 
         symmetryOrdering ::TypeOf_SymmetryOrdering m
         symmetryOrdering innerSO downX1 inp domain = do
-            i <- downX1 inp
-            d <- downD ("SO", domain)
-            case (i,d) of 
-                ([inner],Just [(_,innerDomain)]) -> innerSO downX1 inner innerDomain
-                _ -> na "Pattern match error{symetryOrderingFunc1D}"
+            [inner] <- downX1 inp
+            Just [(_, innerDomain)] <- downD ("SO", domain)
+            innerSO downX1 inner innerDomain
             
 
 

--- a/src/Conjure/Representations/Function/Function1DPartial.hs
+++ b/src/Conjure/Representations/Function/Function1DPartial.hs
@@ -14,7 +14,7 @@ import Conjure.Representations.Function.Function1D ( domainValues )
 import qualified Data.HashMap.Strict as M
 
 
-function1DPartial :: forall m . (MonadFail m, NameGen m, EnumerateDomain m) => Representation m
+function1DPartial :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
 function1DPartial = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -177,26 +177,26 @@ function1DPartial = Representation chck downD structuralCons downC up symmetryOr
                     functionValues <- forM (zip3 flagMatrix froms valuesMatrix) $ \ (flag, from, to) ->
                         case viewConstantBool flag of
                             Just b  -> return $ if b then Just (from,to) else Nothing
-                            Nothing -> fail $ vcat [ "Expected a boolean, but got:" <++> pretty flag
+                            Nothing -> failDoc $ vcat [ "Expected a boolean, but got:" <++> pretty flag
                                                    , "When working on:" <+> pretty name
                                                    , "With domain:" <+> pretty domain
                                                    ]
                     return ( name, ConstantAbstract $ AbsLitFunction $ catMaybes functionValues )
-                (Nothing, _) -> fail $ vcat $
+                (Nothing, _) -> failDoc $ vcat $
                     [ "(in Function1DPartial up 1)"
                     , "No value for:" <+> pretty (nameFlags domain name)
                     , "When working on:" <+> pretty name
                     , "With domain:" <+> pretty domain
                     ] ++
                     ("Bindings in context:" : prettyContext ctxt)
-                (_, Nothing) -> fail $ vcat $
+                (_, Nothing) -> failDoc $ vcat $
                     [ "(in Function1DPartial up 2)"
                     , "No value for:" <+> pretty (nameValues domain name)
                     , "When working on:" <+> pretty name
                     , "With domain:" <+> pretty domain
                     ] ++
                     ("Bindings in context:" : prettyContext ctxt)
-                _ -> fail $ vcat $
+                _ -> failDoc $ vcat $
                     [ "Expected matrix literals for:" <+> pretty (nameFlags domain name)
                                             <+> "and" <+> pretty (nameValues domain name)
                     , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/Function/Function1DPartial.hs
+++ b/src/Conjure/Representations/Function/Function1DPartial.hs
@@ -14,7 +14,7 @@ import Conjure.Representations.Function.Function1D ( domainValues )
 import qualified Data.HashMap.Strict as M
 
 
-function1DPartial :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
+function1DPartial :: forall m . (MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
 function1DPartial = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/Function/FunctionAsRelation.hs
+++ b/src/Conjure/Representations/Function/FunctionAsRelation.hs
@@ -14,7 +14,7 @@ import Conjure.Representations.Internal
 
 
 functionAsRelation
-    :: forall m . (MonadFail m,MonadFailDoc m, NameGen m)
+    :: forall m . (MonadFailDoc m, NameGen m)
     => (forall x . DispatchFunction m x)
     -> (forall r x . ReprOptionsFunction m r x)
     -> Representation m

--- a/src/Conjure/Representations/Function/FunctionAsRelation.hs
+++ b/src/Conjure/Representations/Function/FunctionAsRelation.hs
@@ -14,7 +14,7 @@ import Conjure.Representations.Internal
 
 
 functionAsRelation
-    :: forall m . (MonadFail m, NameGen m)
+    :: forall m . (MonadFailDoc m, NameGen m)
     => (forall x . DispatchFunction m x)
     -> (forall r x . ReprOptionsFunction m r x)
     -> Representation m
@@ -154,17 +154,17 @@ functionAsRelation dispatch reprOptions = Representation chck downD structuralCo
             case lookup (outName domain name) ctxt of
                 Just (viewConstantRelation -> Just  pairs) -> do
                     let pairOut [a,b] = return (a,b)
-                        pairOut c = fail $ "Expecting a 2-tuple, but got:" <++> prettyList prParens "," c
+                        pairOut c = failDoc $ "Expecting a 2-tuple, but got:" <++> prettyList prParens "," c
                     vals <- mapM pairOut pairs
                     return (name, ConstantAbstract (AbsLitFunction vals))
-                Nothing -> fail $ vcat $
+                Nothing -> failDoc $ vcat $
                     [ "(in FunctionAsRelation up)"
                     , "No value for:" <+> pretty (outName domain name)
                     , "When working on:" <+> pretty name
                     , "With domain:" <+> pretty domain
                     ] ++
                     ("Bindings in context:" : prettyContext ctxt)
-                Just constant -> fail $ vcat $
+                Just constant -> failDoc $ vcat $
                     [ "Incompatible value for:" <+> pretty (outName domain name)
                     , "When working on:" <+> pretty name
                     , "With domain:" <+> pretty domain
@@ -178,7 +178,11 @@ functionAsRelation dispatch reprOptions = Representation chck downD structuralCo
 
         symmetryOrdering :: TypeOf_SymmetryOrdering m
         symmetryOrdering innerSO downX1 inp domain = do
-            [rel] <- downX1 inp
-            Just [(_, relDomain)] <- downD ("SO", domain)
-            innerSO downX1 rel relDomain
+            i <- downX1 inp
+            d <- downD ("SO", domain)
+            case (i,d) of 
+                ([rel],Just [(_,relDomain)]) -> innerSO downX1 rel relDomain
+                _ -> na "Pattern match error{symetryOrderingFuncAsRel}"
+        -- symOrdNMF = 
+
 

--- a/src/Conjure/Representations/Function/FunctionAsRelation.hs
+++ b/src/Conjure/Representations/Function/FunctionAsRelation.hs
@@ -180,8 +180,5 @@ functionAsRelation dispatch reprOptions = Representation chck downD structuralCo
         symmetryOrdering innerSO downX1 inp domain = do
 
             [rel] <- downX1 inp
-            Just [(_,relDomain)]<- downD ("SO", domain)
+            Just [(_, relDomain)] <- downD ("SO", domain)
             innerSO downX1 rel relDomain
-
-
-

--- a/src/Conjure/Representations/Function/FunctionAsRelation.hs
+++ b/src/Conjure/Representations/Function/FunctionAsRelation.hs
@@ -14,7 +14,7 @@ import Conjure.Representations.Internal
 
 
 functionAsRelation
-    :: forall m . (MonadFailDoc m, NameGen m)
+    :: forall m . (MonadFail m,MonadFailDoc m, NameGen m)
     => (forall x . DispatchFunction m x)
     -> (forall r x . ReprOptionsFunction m r x)
     -> Representation m
@@ -178,11 +178,10 @@ functionAsRelation dispatch reprOptions = Representation chck downD structuralCo
 
         symmetryOrdering :: TypeOf_SymmetryOrdering m
         symmetryOrdering innerSO downX1 inp domain = do
-            i <- downX1 inp
-            d <- downD ("SO", domain)
-            case (i,d) of 
-                ([rel],Just [(_,relDomain)]) -> innerSO downX1 rel relDomain
-                _ -> na "Pattern match error{symetryOrderingFuncAsRel}"
-        -- symOrdNMF = 
+
+            [rel] <- downX1 inp
+            Just [(_,relDomain)]<- downD ("SO", domain)
+            innerSO downX1 rel relDomain
+
 
 

--- a/src/Conjure/Representations/Function/FunctionND.hs
+++ b/src/Conjure/Representations/Function/FunctionND.hs
@@ -17,7 +17,7 @@ import Conjure.Representations.Common
 import Conjure.Representations.Function.Function1D ( domainValues )
 
 
-functionND :: forall m . (MonadFail m,MonadFailDoc  m, NameGen m, ?typeCheckerMode :: TypeCheckerMode) => Representation m
+functionND :: forall m . (MonadFailDoc  m, NameGen m, ?typeCheckerMode :: TypeCheckerMode) => Representation m
 functionND = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -222,10 +222,10 @@ functionND = Representation chck downD structuralCons downC up symmetryOrdering
             case lookup (nameValues domain name) ctxt of
                 Just valuesMatrix -> do
                     let
-                        allIndices :: (MonadFail m, Pretty r) => [Domain r Constant] -> m [[Constant]]
+                        allIndices :: ( Pretty r) => [Domain r Constant] -> m [[Constant]]
                         allIndices = fmap sequence . mapM domainValues
 
-                        index :: MonadFail m => Constant -> [Constant] -> m Constant
+                        index ::  Constant -> [Constant] -> m Constant
                         index m [] = return m
                         index (ConstantAbstract (AbsLitMatrix indexDomain vals)) (i:is) = do
                             froms <- domainValues indexDomain

--- a/src/Conjure/Representations/Function/FunctionND.hs
+++ b/src/Conjure/Representations/Function/FunctionND.hs
@@ -222,10 +222,10 @@ functionND = Representation chck downD structuralCons downC up symmetryOrdering
             case lookup (nameValues domain name) ctxt of
                 Just valuesMatrix -> do
                     let
-                        allIndices :: ( Pretty r) => [Domain r Constant] -> m [[Constant]]
+                        allIndices :: (MonadFailDoc  m, Pretty r) => [Domain r Constant] -> m [[Constant]]
                         allIndices = fmap sequence . mapM domainValues
 
-                        index ::  Constant -> [Constant] -> m Constant
+                        index :: MonadFailDoc  m => Constant -> [Constant] -> m Constant
                         index m [] = return m
                         index (ConstantAbstract (AbsLitMatrix indexDomain vals)) (i:is) = do
                             froms <- domainValues indexDomain

--- a/src/Conjure/Representations/Function/FunctionND.hs
+++ b/src/Conjure/Representations/Function/FunctionND.hs
@@ -17,7 +17,7 @@ import Conjure.Representations.Common
 import Conjure.Representations.Function.Function1D ( domainValues )
 
 
-functionND :: forall m . (MonadFail m, NameGen m, ?typeCheckerMode :: TypeCheckerMode) => Representation m
+functionND :: forall m . (MonadFail m,MonadFailDoc  m, NameGen m, ?typeCheckerMode :: TypeCheckerMode) => Representation m
 functionND = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -183,7 +183,7 @@ functionND = Representation chck downD structuralCons downC up symmetryOrdering
                             Just {} -> return []
 
                     unless (null missing) $
-                        fail $ vcat [ "Some points are undefined on a total function:" <++> prettyList id "," missing
+                        failDoc $ vcat [ "Some points are undefined on a total function:" <++> prettyList id "," missing
                                     , "    Function:" <+> pretty name
                                     , "    Domain:" <++> pretty domain
                                     , "    Value :" <++> pretty value
@@ -197,7 +197,7 @@ functionND = Representation chck downD structuralCons downC up symmetryOrdering
                     matrixVals <- forM domVals $ \ val ->
                         unrollC is (prevIndices ++ [val])
                     return $ ConstantAbstract $ AbsLitMatrix i matrixVals
-                unrollC is prevIndices = fail $ vcat [ "FunctionND.up.unrollC"
+                unrollC is prevIndices = failDoc $ vcat [ "FunctionND.up.unrollC"
                                                      , "    is         :" <+> vcat (map pretty is)
                                                      , "    prevIndices:" <+> pretty (show prevIndices)
                                                      ]
@@ -230,7 +230,7 @@ functionND = Representation chck downD structuralCons downC up symmetryOrdering
                         index (ConstantAbstract (AbsLitMatrix indexDomain vals)) (i:is) = do
                             froms <- domainValues indexDomain
                             case lookup i (zip froms vals) of
-                                Nothing -> fail "Value not found. FunctionND.up.index"
+                                Nothing -> failDoc "Value not found. FunctionND.up.index"
                                 Just v  -> index v is
                         index m is = bug ("FunctionND.up.index" <+> pretty m <+> pretty (show is))
 
@@ -241,7 +241,7 @@ functionND = Representation chck downD structuralCons downC up symmetryOrdering
                     return ( name
                            , ConstantAbstract $ AbsLitFunction vals
                            )
-                Nothing -> fail $ vcat $
+                Nothing -> failDoc $ vcat $
                     [ "(in FunctionND up)"
                     , "No value for:" <+> pretty (nameValues domain name)
                     , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/Function/FunctionNDPartialDummy.hs
+++ b/src/Conjure/Representations/Function/FunctionNDPartialDummy.hs
@@ -16,7 +16,6 @@ import Conjure.Representations.Function.FunctionND ( viewAsDomainTupleS, mkLensA
 
 
 functionNDPartialDummy :: forall m .
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -235,10 +234,10 @@ functionNDPartialDummy = Representation chck downD structuralCons downC up symme
             case lookup (outName domain name) ctxt of
                 Just valuesMatrix -> do
                     let
-                        allIndices :: (MonadFail m, Pretty r) => [Domain r Constant] -> m [[Constant]]
+                        allIndices :: (Pretty r) => [Domain r Constant] -> m [[Constant]]
                         allIndices = fmap sequence . mapM domainValues
 
-                        index :: MonadFail m => Constant -> [Constant] -> m Constant
+                        index :: MonadFailDoc m =>  Constant -> [Constant] -> m Constant
                         index m [] = return m
                         index (ConstantAbstract (AbsLitMatrix indexDomain vals)) (i:is) = do
                             froms <- domainValues indexDomain

--- a/src/Conjure/Representations/Function/FunctionNDPartialDummy.hs
+++ b/src/Conjure/Representations/Function/FunctionNDPartialDummy.hs
@@ -17,6 +17,7 @@ import Conjure.Representations.Function.FunctionND ( viewAsDomainTupleS, mkLensA
 
 functionNDPartialDummy :: forall m .
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -209,7 +210,7 @@ functionNDPartialDummy = Representation chck downD structuralCons downC up symme
                     matrixVals <- forM domVals $ \ val ->
                         unrollC is (prevIndices ++ [val])
                     return $ ConstantAbstract $ AbsLitMatrix i matrixVals
-                unrollC is prevIndices = fail $ vcat [ "FunctionNDPartialDummy.up.unrollC"
+                unrollC is prevIndices = failDoc $ vcat [ "FunctionNDPartialDummy.up.unrollC"
                                                      , "    is         :" <+> vcat (map pretty is)
                                                      , "    prevIndices:" <+> pretty (show prevIndices)
                                                      ]
@@ -242,7 +243,7 @@ functionNDPartialDummy = Representation chck downD structuralCons downC up symme
                         index (ConstantAbstract (AbsLitMatrix indexDomain vals)) (i:is) = do
                             froms <- domainValues indexDomain
                             case lookup i (zip froms vals) of
-                                Nothing -> fail "Value not found. FunctionND.up.index"
+                                Nothing -> failDoc "Value not found. FunctionND.up.index"
                                 Just v  -> index v is
                         index m is = bug ("FunctionND.up.index" <+> pretty m <+> pretty (show is))
 
@@ -257,7 +258,7 @@ functionNDPartialDummy = Representation chck downD structuralCons downC up symme
                     return ( name
                            , ConstantAbstract $ AbsLitFunction (catMaybes vals)
                            )
-                Nothing -> fail $ vcat $
+                Nothing -> failDoc $ vcat $
                     [ "(in FunctionNDPartialDummy up)"
                     , "No value for:" <+> pretty (outName domain name)
                     , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/MSet/ExplicitWithFlags.hs
+++ b/src/Conjure/Representations/MSet/ExplicitWithFlags.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-msetExplicitWithFlags :: forall m . (MonadFail m, NameGen m, EnumerateDomain m) => Representation m
+msetExplicitWithFlags :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
 msetExplicitWithFlags = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -31,7 +31,7 @@ msetExplicitWithFlags = Representation chck downD structuralCons downC up symmet
             MSetAttr (SizeAttr_MinMaxSize _ x) _ -> return x
             MSetAttr _ (OccurAttr_MaxOccur x) -> do y <- domainSizeOf innerDomain ; return (x * y)
             MSetAttr _ (OccurAttr_MinMaxOccur _ x) -> do y <- domainSizeOf innerDomain ; return (x * y)
-            _ -> fail ("getMaxSize, mset not supported. attributes:" <+> pretty attrs)
+            _ -> failDoc ("getMaxSize, mset not supported. attributes:" <+> pretty attrs)
 
         getMinOccur attrs = case attrs of
             MSetAttr _ (OccurAttr_MinOccur x) -> Just x
@@ -44,7 +44,7 @@ msetExplicitWithFlags = Representation chck downD structuralCons downC up symmet
             MSetAttr (SizeAttr_Size x) _ -> return x
             MSetAttr (SizeAttr_MaxSize x) _ -> return x
             MSetAttr (SizeAttr_MinMaxSize _ x) _ -> return x
-            _ -> fail ("getMaxOccur, mset not supported. attributes:" <+> pretty attrs)
+            _ -> failDoc ("getMaxOccur, mset not supported. attributes:" <+> pretty attrs)
 
         downD :: TypeOf_DownD m
         downD (name, domain@(DomainMSet _ attrs innerDomain)) = do
@@ -140,7 +140,7 @@ msetExplicitWithFlags = Representation chck downD structuralCons downC up symmet
             maxSizeInt <-
                 case maxSize of
                     ConstantInt _ x -> return x
-                    _ -> fail $ vcat
+                    _ -> failDoc $ vcat
                             [ "Expecting an integer for the maxSize attribute."
                             , "But got:" <+> pretty maxSize
                             , "When working on:" <+> pretty name
@@ -177,26 +177,26 @@ msetExplicitWithFlags = Representation chck downD structuralCons downC up symmet
                                                     [ replicate (fromInteger i) v
                                                     | (ConstantInt TagInt i,v) <- zip flags vals
                                                     ] )
-                                _ -> fail $ vcat
+                                _ -> failDoc $ vcat
                                         [ "Expecting a matrix literal for:" <+> pretty (nameValues domain name)
                                         , "But got:" <+> pretty constantMatrix
                                         , "When working on:" <+> pretty name
                                         , "With domain:" <+> pretty domain
                                         ]
-                        _ -> fail $ vcat
+                        _ -> failDoc $ vcat
                                 [ "Expecting a matrix literal for:" <+> pretty (nameFlag domain name)
                                 , "But got:" <+> pretty flagMatrix
                                 , "When working on:" <+> pretty name
                                 , "With domain:" <+> pretty domain
                                 ]
-                (Nothing, _) -> fail $ vcat $
+                (Nothing, _) -> failDoc $ vcat $
                     [ "(in MSet ExplicitVarSizeWithFlags up 1)"
                     , "No value for:" <+> pretty (nameFlag domain name)
                     , "When working on:" <+> pretty name
                     , "With domain:" <+> pretty domain
                     ] ++
                     ("Bindings in context:" : prettyContext ctxt)
-                (_, Nothing) -> fail $ vcat $
+                (_, Nothing) -> failDoc $ vcat $
                     [ "(in MSet ExplicitVarSizeWithFlags up 2)"
                     , "No value for:" <+> pretty (nameValues domain name)
                     , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/MSet/ExplicitWithFlags.hs
+++ b/src/Conjure/Representations/MSet/ExplicitWithFlags.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-msetExplicitWithFlags :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
+msetExplicitWithFlags :: forall m . (MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
 msetExplicitWithFlags = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/MSet/ExplicitWithRepetition.hs
+++ b/src/Conjure/Representations/MSet/ExplicitWithRepetition.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-msetExplicitWithRepetition :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
+msetExplicitWithRepetition :: forall m . (MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
 msetExplicitWithRepetition = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/MSet/ExplicitWithRepetition.hs
+++ b/src/Conjure/Representations/MSet/ExplicitWithRepetition.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-msetExplicitWithRepetition :: forall m . (MonadFail m, NameGen m, EnumerateDomain m) => Representation m
+msetExplicitWithRepetition :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
 msetExplicitWithRepetition = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -31,7 +31,7 @@ msetExplicitWithRepetition = Representation chck downD structuralCons downC up s
             MSetAttr (SizeAttr_MinMaxSize _ x) _ -> return x
             MSetAttr _ (OccurAttr_MaxOccur x) -> do y <- domainSizeOf innerDomain ; return (x * y)
             MSetAttr _ (OccurAttr_MinMaxOccur _ x) -> do y <- domainSizeOf innerDomain ; return (x * y)
-            _ -> fail ("getMaxSize, mset not supported. attributes:" <+> pretty attrs)
+            _ -> failDoc ("getMaxSize, mset not supported. attributes:" <+> pretty attrs)
 
         getMinOccur attrs = case attrs of
             MSetAttr _ (OccurAttr_MinOccur x) -> Just x
@@ -41,7 +41,7 @@ msetExplicitWithRepetition = Representation chck downD structuralCons downC up s
         getMaxOccur attrs = case attrs of
             MSetAttr _ (OccurAttr_MaxOccur x) -> return x
             MSetAttr _ (OccurAttr_MinMaxOccur _ x) -> return x
-            _ -> fail ("getMaxOccur, mset not supported. attributes:" <+> pretty attrs)
+            _ -> failDoc ("getMaxOccur, mset not supported. attributes:" <+> pretty attrs)
 
         downD :: TypeOf_DownD m
         downD (name, domain@(DomainMSet _ attrs innerDomain)) = do
@@ -157,7 +157,7 @@ msetExplicitWithRepetition = Representation chck downD structuralCons downC up s
                         maxSizeInt <-
                             case maxSize of
                                 ConstantInt _ x -> return x
-                                _ -> fail $ vcat
+                                _ -> failDoc $ vcat
                                         [ "Expecting an integer for the maxSize attribute."
                                         , "But got:" <+> pretty maxSize
                                         , "When working on:" <+> pretty name
@@ -193,26 +193,26 @@ msetExplicitWithRepetition = Representation chck downD structuralCons downC up s
                                 Just (_, vals) ->
                                     return (name, ConstantAbstract $ AbsLitMSet
                                                     (genericTake flagInt vals) )
-                                _ -> fail $ vcat
+                                _ -> failDoc $ vcat
                                         [ "Expecting a matrix literal for:" <+> pretty (nameValues domain name)
                                         , "But got:" <+> pretty constantMatrix
                                         , "When working on:" <+> pretty name
                                         , "With domain:" <+> pretty domain
                                         ]
-                        _ -> fail $ vcat
+                        _ -> failDoc $ vcat
                                 [ "Expecting an integer literal for:" <+> pretty (nameFlag domain name)
                                 , "But got:" <+> pretty flag
                                 , "When working on:" <+> pretty name
                                 , "With domain:" <+> pretty domain
                                 ]
-                (Nothing, _) -> fail $ vcat $
+                (Nothing, _) -> failDoc $ vcat $
                     [ "(in MSet ExplicitVarSizeWithRepetition up 1)"
                     , "No value for:" <+> pretty (nameFlag domain name)
                     , "When working on:" <+> pretty name
                     , "With domain:" <+> pretty domain
                     ] ++
                     ("Bindings in context:" : prettyContext ctxt)
-                (_, Nothing) -> fail $ vcat $
+                (_, Nothing) -> failDoc $ vcat $
                     [ "(in MSet ExplicitVarSizeWithRepetition up 2)"
                     , "No value for:" <+> pretty (nameValues domain name)
                     , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/MSet/Occurrence.hs
+++ b/src/Conjure/Representations/MSet/Occurrence.hs
@@ -9,7 +9,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-msetOccurrence :: forall m . (MonadFail m,MonadFailDoc m, NameGen m) => Representation m
+msetOccurrence :: forall m . (MonadFailDoc m, NameGen m) => Representation m
 msetOccurrence = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/MSet/Occurrence.hs
+++ b/src/Conjure/Representations/MSet/Occurrence.hs
@@ -9,7 +9,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-msetOccurrence :: forall m . (MonadFail m, NameGen m) => Representation m
+msetOccurrence :: forall m . (MonadFail m,MonadFailDoc m, NameGen m) => Representation m
 msetOccurrence = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -32,7 +32,7 @@ msetOccurrence = Representation chck downD structuralCons downC up symmetryOrder
             MSetAttr (SizeAttr_Size x) _ -> return x
             MSetAttr (SizeAttr_MaxSize x) _ -> return x
             MSetAttr (SizeAttr_MinMaxSize _ x) _ -> return x
-            _ -> fail ("getMaxOccur, mset not supported. attributes:" <+> pretty attrs)
+            _ -> failDoc ("getMaxOccur, mset not supported. attributes:" <+> pretty attrs)
 
         downD :: TypeOf_DownD m
         downD (name, domain@(DomainMSet MSet_Occurrence attrs innerDomain@DomainInt{})) = do
@@ -96,13 +96,13 @@ msetOccurrence = Representation chck downD structuralCons downC up symmetryOrder
                                                 Nothing -> []
                                             | (v,x) <- zip innerDomainVals vals
                                             ] )
-                        _ -> fail $ vcat
+                        _ -> failDoc $ vcat
                                 [ "Expecting a matrix literal for:" <+> pretty (outName domain name)
                                 , "But got:" <+> pretty constantMatrix
                                 , "When working on:" <+> pretty name
                                 , "With domain:" <+> pretty domain
                                 ]
-                Nothing -> fail $ vcat $
+                Nothing -> failDoc $ vcat $
                     [ "(in MSet Occurrence up)"
                     , "No value for:" <+> pretty (outName domain name)
                     , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/Matrix.hs
+++ b/src/Conjure/Representations/Matrix.hs
@@ -16,7 +16,7 @@ import Conjure.Representations.Internal
 -- | The matrix "representation rule".
 --   This rule handles the plumbing for matrices.
 matrix
-    :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, MonadUserError m, EnumerateDomain m, ?typeCheckerMode :: TypeCheckerMode)
+    :: forall m . (MonadFailDoc m, NameGen m, MonadUserError m, EnumerateDomain m, ?typeCheckerMode :: TypeCheckerMode)
     => ((Name, DomainX Expression) -> m (Maybe [(Name, DomainX Expression)]))
     -> ((Name, DomainC, Constant) -> m (Maybe [(Name, DomainC, Constant)]))
     -> ((Name, DomainC) -> [(Name, Constant)] -> m (Name, Constant))

--- a/src/Conjure/Representations/Matrix.hs
+++ b/src/Conjure/Representations/Matrix.hs
@@ -16,7 +16,7 @@ import Conjure.Representations.Internal
 -- | The matrix "representation rule".
 --   This rule handles the plumbing for matrices.
 matrix
-    :: forall m . (MonadFail m, NameGen m, MonadUserError m, EnumerateDomain m, ?typeCheckerMode :: TypeCheckerMode)
+    :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, MonadUserError m, EnumerateDomain m, ?typeCheckerMode :: TypeCheckerMode)
     => ((Name, DomainX Expression) -> m (Maybe [(Name, DomainX Expression)]))
     -> ((Name, DomainC, Constant) -> m (Maybe [(Name, DomainC, Constant)]))
     -> ((Name, DomainC) -> [(Name, Constant)] -> m (Name, Constant))
@@ -107,7 +107,7 @@ matrix downD1 downC1 up1 = Representation chck matrixDownD structuralCons matrix
                                 | (n, d, cs) <- mids3
                                 ]
                         else
-                            fail $ vcat
+                            failDoc $ vcat
                                 [ "This is weird. Heterogeneous matrix literal?"
                                 , "When working on:" <+> pretty name
                                 , "With domain:" <+> pretty (DomainMatrix indexDomain innerDomain)
@@ -127,7 +127,7 @@ matrix downD1 downC1 up1 = Representation chck matrixDownD structuralCons matrix
                     -- there needs to be a binding with "name"
                     -- and we just pass it through
                     case lookup name ctxt of
-                        Nothing -> fail $ vcat $
+                        Nothing -> failDoc $ vcat $
                             [ "(in Matrix up 1)"
                             , "No value for:" <+> pretty name
                             , "With domain:" <+> pretty (DomainMatrix indexDomain innerDomain)
@@ -142,7 +142,7 @@ matrix downD1 downC1 up1 = Representation chck matrixDownD structuralCons matrix
                         :: [(Name, [Constant])]
                         <- forM mid2 $ \ (n, _) ->
                             case lookup n ctxt of
-                                Nothing -> fail $ vcat $
+                                Nothing -> failDoc $ vcat $
                                     [ "(in Matrix up 2)"
                                     , "No value for:" <+> pretty n
                                     , "When working on:" <+> pretty name
@@ -153,7 +153,7 @@ matrix downD1 downC1 up1 = Representation chck matrixDownD structuralCons matrix
                                     -- this constant is a ConstantMatrix, containing one component of the things to go into up1
                                     case viewConstantMatrix constant of
                                         Just (_, vals) -> return (n, vals)
-                                        _ -> fail $ vcat
+                                        _ -> failDoc $ vcat
                                             [ "Expecting a matrix literal for:" <+> pretty n
                                             , "But got:" <+> pretty constant
                                             , "When working on:" <+> pretty name
@@ -178,7 +178,7 @@ matrix downD1 downC1 up1 = Representation chck matrixDownD structuralCons matrix
 
                     -- -- assertion, midConstants should not be rugged
                     -- case midConstants of
-                    --     (x:xs) | any (length x /=) (map length xs) -> fail $ vcat
+                    --     (x:xs) | any (length x /=) (map length xs) -> failDoc $ vcat
                     --         [ "midConstants is rugged"
                     --         , "midConstants      :" <+> vcat (map (prettyList prBrackets ",") midConstants)
                     --         , "midConstantsPadded:" <+> vcat (map (prettyList prBrackets ",") midConstantsPadded)

--- a/src/Conjure/Representations/Partition/Occurrence.hs
+++ b/src/Conjure/Representations/Partition/Occurrence.hs
@@ -23,7 +23,7 @@ import Conjure.Representations.Function.Function1D ( domainValues )
 --      (indicating the total number of parts)
 --   only use part numbers from 1.._NumParts, never use the others
 --      part(i) is used -> part(i-1) is used, forAll i:int(3..maxNumParts)
-partitionOccurrence :: forall m . (MonadFail m, NameGen m, EnumerateDomain m) => Representation m
+partitionOccurrence :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
 partitionOccurrence = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -284,7 +284,7 @@ partitionOccurrence = Representation chck downD structuralCons downC up symmetry
                             | bucket <- [1..numPartsValue]
                             ]
                         )
-                (Just val, _) -> fail $ vcat $
+                (Just val, _) -> failDoc $ vcat $
                     [ "(in Partition Occurrence up)"
                     , "Expecting an integer literal for:" <+> pretty (nameNumParts domain name)
                     , "But got:" <+> pretty val
@@ -292,7 +292,7 @@ partitionOccurrence = Representation chck downD structuralCons downC up symmetry
                     , "With domain:" <+> pretty domain
                     ] ++
                     ("Bindings in context:" : prettyContext ctxt)
-                (_, Just val) -> fail $ vcat $
+                (_, Just val) -> failDoc $ vcat $
                     [ "(in Partition Occurrence up)"
                     , "Expecting a matrix literal for:" <+> pretty (nameWhichPart domain name)
                     , "But got:" <+> pretty val
@@ -300,7 +300,7 @@ partitionOccurrence = Representation chck downD structuralCons downC up symmetry
                     , "With domain:" <+> pretty domain
                     ] ++
                     ("Bindings in context:" : prettyContext ctxt)
-                (Nothing, _) -> fail $ vcat $
+                (Nothing, _) -> failDoc $ vcat $
                     [ "(in Partition Occurrence up)"
                     , "No value for:" <+> pretty (nameNumParts domain name)
                     , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/Partition/Occurrence.hs
+++ b/src/Conjure/Representations/Partition/Occurrence.hs
@@ -23,7 +23,7 @@ import Conjure.Representations.Function.Function1D ( domainValues )
 --      (indicating the total number of parts)
 --   only use part numbers from 1.._NumParts, never use the others
 --      part(i) is used -> part(i-1) is used, forAll i:int(3..maxNumParts)
-partitionOccurrence :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
+partitionOccurrence :: forall m . (MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
 partitionOccurrence = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/Partition/PartitionAsSet.hs
+++ b/src/Conjure/Representations/Partition/PartitionAsSet.hs
@@ -17,7 +17,7 @@ import Conjure.Representations.Internal
 
 
 partitionAsSet
-    :: forall m . (MonadFail m, NameGen m, ?typeCheckerMode :: TypeCheckerMode)
+    :: forall m . (MonadFailDoc m, NameGen m, ?typeCheckerMode :: TypeCheckerMode)
     => (forall x . DispatchFunction m x)
     -> (forall r x . ReprOptionsFunction m r x)
     -> Bool
@@ -171,7 +171,7 @@ partitionAsSet dispatch reprOptions useLevels = Representation chck downD struct
         up :: TypeOf_Up m
         up ctxt (name, domain@(DomainPartition Partition_AsSet{} _ _)) =
             case lookup (outName domain name) ctxt of
-                Nothing -> fail $ vcat $
+                Nothing -> failDoc $ vcat $
                     [ "(in PartitionAsSet up)"
                     , "No value for:" <+> pretty (outName domain name)
                     , "When working on:" <+> pretty name
@@ -180,12 +180,12 @@ partitionAsSet dispatch reprOptions useLevels = Representation chck downD struct
                     ("Bindings in context:" : prettyContext ctxt)
                 Just (viewConstantSet -> Just sets) -> do
                     let setOut (viewConstantSet -> Just xs) = return xs
-                        setOut c = fail $ "Expecting a set, but got:" <++> pretty c
+                        setOut c = failDoc $ "Expecting a set, but got:" <++> pretty c
                     vals <- mapM setOut sets
                     return (name, ConstantAbstract (AbsLitPartition vals))
                 Just (ConstantUndefined msg ty) ->        -- undefined propagates
                     return (name, ConstantUndefined ("PartitionAsSet " `mappend` msg) ty)
-                Just constant -> fail $ vcat $
+                Just constant -> failDoc $ vcat $
                     [ "Incompatible value for:" <+> pretty (outName domain name)
                     , "When working on:" <+> pretty name
                     , "With domain:" <+> pretty domain
@@ -199,6 +199,8 @@ partitionAsSet dispatch reprOptions useLevels = Representation chck downD struct
 
         symmetryOrdering :: TypeOf_SymmetryOrdering m
         symmetryOrdering innerSO downX1 inp domain = do
-            [inner] <- downX1 inp
-            Just [(_, innerDomain)] <- downD ("SO", domain)
-            innerSO downX1 inner innerDomain
+            i <- downX1 inp
+            d <- downD ("SO", domain)
+            case (i,d) of 
+                ([inner],Just [(_,innerDomain)]) -> innerSO downX1 inner innerDomain
+                _ -> na "Pattern match error{symetryOrderingFunc1D}"

--- a/src/Conjure/Representations/Partition/PartitionAsSet.hs
+++ b/src/Conjure/Representations/Partition/PartitionAsSet.hs
@@ -17,7 +17,7 @@ import Conjure.Representations.Internal
 
 
 partitionAsSet
-    :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, ?typeCheckerMode :: TypeCheckerMode)
+    :: forall m . (MonadFailDoc m, NameGen m, ?typeCheckerMode :: TypeCheckerMode)
     => (forall x . DispatchFunction m x)
     -> (forall r x . ReprOptionsFunction m r x)
     -> Bool

--- a/src/Conjure/Representations/Partition/PartitionAsSet.hs
+++ b/src/Conjure/Representations/Partition/PartitionAsSet.hs
@@ -17,7 +17,7 @@ import Conjure.Representations.Internal
 
 
 partitionAsSet
-    :: forall m . (MonadFailDoc m, NameGen m, ?typeCheckerMode :: TypeCheckerMode)
+    :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, ?typeCheckerMode :: TypeCheckerMode)
     => (forall x . DispatchFunction m x)
     -> (forall r x . ReprOptionsFunction m r x)
     -> Bool
@@ -199,8 +199,6 @@ partitionAsSet dispatch reprOptions useLevels = Representation chck downD struct
 
         symmetryOrdering :: TypeOf_SymmetryOrdering m
         symmetryOrdering innerSO downX1 inp domain = do
-            i <- downX1 inp
-            d <- downD ("SO", domain)
-            case (i,d) of 
-                ([inner],Just [(_,innerDomain)]) -> innerSO downX1 inner innerDomain
-                _ -> na "Pattern match error{symetryOrderingFunc1D}"
+            [inner] <- downX1 inp
+            Just [(_, innerDomain)] <- downD ("SO", domain)
+            innerSO downX1 inner innerDomain

--- a/src/Conjure/Representations/Primitive.hs
+++ b/src/Conjure/Representations/Primitive.hs
@@ -10,7 +10,7 @@ import Conjure.Language
 import Conjure.Representations.Internal
 
 
-primitive :: forall m . MonadFail m => Representation m
+primitive :: forall m . MonadFailDoc m => Representation m
 primitive = Representation
     { rCheck = \ _ domain -> return $
         case domain of
@@ -23,7 +23,7 @@ primitive = Representation
     , rDownC      = const $ return Nothing
     , rUp         = \ ctxt (name, _) ->
         case lookup name ctxt of
-            Nothing -> fail $ vcat
+            Nothing -> failDoc $ vcat
                 $ ("No value for:" <+> pretty name)
                 : "Bindings in context:"
                 : prettyContext ctxt

--- a/src/Conjure/Representations/Record.hs
+++ b/src/Conjure/Representations/Record.hs
@@ -11,7 +11,7 @@ import Conjure.Language
 import Conjure.Representations.Internal
 
 
-record :: forall m . (MonadFail m,MonadFailDoc m, NameGen m) => Representation m
+record :: forall m . (MonadFailDoc m, NameGen m) => Representation m
 record = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/Record.hs
+++ b/src/Conjure/Representations/Record.hs
@@ -11,7 +11,7 @@ import Conjure.Language
 import Conjure.Representations.Internal
 
 
-record :: forall m . (MonadFail m, NameGen m) => Representation m
+record :: forall m . (MonadFail m,MonadFailDoc m, NameGen m) => Representation m
 record = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -65,7 +65,7 @@ record = Representation chck downD structuralCons downC up symmetryOrdering
             let names = map (mkName name . fst) ds
             vals <- forM names $ \ n ->
                 case lookup n ctxt of
-                    Nothing -> fail $ vcat $
+                    Nothing -> failDoc $ vcat $
                         [ "(in Record up)"
                         , "No value for:" <+> pretty n
                         , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/Relation/RelationAsMatrix.hs
+++ b/src/Conjure/Representations/Relation/RelationAsMatrix.hs
@@ -11,7 +11,7 @@ import Conjure.Representations.Common
 import Conjure.Representations.Function.Function1D ( domainValues )
 
 
-relationAsMatrix :: forall m . (MonadFail m,MonadFailDoc m, NameGen m) => Representation m
+relationAsMatrix :: forall m . (MonadFailDoc m, NameGen m) => Representation m
 relationAsMatrix = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -133,10 +133,10 @@ relationAsMatrix = Representation chck downD structuralCons downC up symmetryOrd
                     ("Bindings in context:" : prettyContext ctxt)
                 Just constant -> do
                     let
-                        allIndices :: (MonadFail m, Pretty r) => [Domain r Constant] -> m [[Constant]]
+                        allIndices :: ( Pretty r) => [Domain r Constant] -> m [[Constant]]
                         allIndices = fmap sequence . mapM domainValues
 
-                        index :: MonadFail m => Constant -> [Constant] -> m Constant
+                        index :: MonadFailDoc m => Constant -> [Constant] -> m Constant
                         index m [] = return m
                         index (ConstantAbstract (AbsLitMatrix indexDomain vals)) (i:is) = do
                             froms <- domainValues indexDomain

--- a/src/Conjure/Representations/Relation/RelationAsMatrix.hs
+++ b/src/Conjure/Representations/Relation/RelationAsMatrix.hs
@@ -11,7 +11,7 @@ import Conjure.Representations.Common
 import Conjure.Representations.Function.Function1D ( domainValues )
 
 
-relationAsMatrix :: forall m . (MonadFail m, NameGen m) => Representation m
+relationAsMatrix :: forall m . (MonadFail m,MonadFailDoc m, NameGen m) => Representation m
 relationAsMatrix = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -42,7 +42,7 @@ relationAsMatrix = Representation chck downD structuralCons downC up symmetryOrd
             (DomainRelation Relation_AsMatrix (RelationAttr sizeAttr binRelAttr) innerDomains)
                 | all domainCanIndexMatrix innerDomains = do
             let cardinality m = do
-                    let unroll _ [] = fail "RelationAsMatrix.cardinality.unroll []"
+                    let unroll _ [] = failDoc "RelationAsMatrix.cardinality.unroll []"
                         unroll n [dom] = do
                             (iPat, i) <- quantifiedVar
                             return [essence| sum &iPat : &dom . toInt(&n[&i]) |]
@@ -101,7 +101,7 @@ relationAsMatrix = Representation chck downD structuralCons downC up symmetryOrd
                     matrixVals <- forM domVals $ \ val ->
                         unrollC is (prevIndices ++ [val])
                     return $ ConstantAbstract $ AbsLitMatrix i matrixVals
-                unrollC is prevIndices = fail $ vcat [ "RelationAsMatrix.up.unrollC"
+                unrollC is prevIndices = failDoc $ vcat [ "RelationAsMatrix.up.unrollC"
                                                      , "    is         :" <+> vcat (map pretty is)
                                                      , "    prevIndices:" <+> pretty (show prevIndices)
                                                      ]
@@ -124,7 +124,7 @@ relationAsMatrix = Representation chck downD structuralCons downC up symmetryOrd
         up ctxt (name, domain@(DomainRelation Relation_AsMatrix _ innerDomains)) =
 
             case lookup (outName domain name) ctxt of
-                Nothing -> fail $ vcat $
+                Nothing -> failDoc $ vcat $
                     [ "(in RelationAsMatrix up)"
                     , "No value for:" <+> pretty (outName domain name)
                     , "When working on:" <+> pretty name
@@ -141,9 +141,9 @@ relationAsMatrix = Representation chck downD structuralCons downC up symmetryOrd
                         index (ConstantAbstract (AbsLitMatrix indexDomain vals)) (i:is) = do
                             froms <- domainValues indexDomain
                             case lookup i (zip froms vals) of
-                                Nothing -> fail "Value not found. RelationAsMatrix.up.index"
+                                Nothing -> failDoc "Value not found. RelationAsMatrix.up.index"
                                 Just v  -> index v is
-                        index m is = fail ("RelationAsMatrix.up.index" <+> pretty m <+> pretty (show is))
+                        index m is = failDoc ("RelationAsMatrix.up.index" <+> pretty m <+> pretty (show is))
 
                     indices  <- allIndices innerDomains
                     vals     <- forM indices $ \ these -> do
@@ -151,7 +151,7 @@ relationAsMatrix = Representation chck downD structuralCons downC up symmetryOrd
                         case viewConstantBool indexed of
                             Just False -> return Nothing
                             Just True  -> return (Just these)
-                            _ -> fail $ vcat
+                            _ -> failDoc $ vcat
                                 [ "Expecting a boolean literal, but got:" <++> pretty indexed
                                 , "When working on:" <+> pretty name
                                 , "With domain:" <+> pretty domain

--- a/src/Conjure/Representations/Relation/RelationAsMatrix.hs
+++ b/src/Conjure/Representations/Relation/RelationAsMatrix.hs
@@ -133,7 +133,7 @@ relationAsMatrix = Representation chck downD structuralCons downC up symmetryOrd
                     ("Bindings in context:" : prettyContext ctxt)
                 Just constant -> do
                     let
-                        allIndices :: ( Pretty r) => [Domain r Constant] -> m [[Constant]]
+                        allIndices :: (MonadFailDoc m, Pretty r) => [Domain r Constant] -> m [[Constant]]
                         allIndices = fmap sequence . mapM domainValues
 
                         index :: MonadFailDoc m => Constant -> [Constant] -> m Constant

--- a/src/Conjure/Representations/Relation/RelationAsSet.hs
+++ b/src/Conjure/Representations/Relation/RelationAsSet.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Common
 
 
 relationAsSet
-    :: forall m . (MonadFail m,MonadFailDoc  m, NameGen m)
+    :: forall m . (MonadFailDoc  m, NameGen m)
     => (forall x . DispatchFunction m x)
     -> (forall r x . ReprOptionsFunction m r x)
     -> Bool

--- a/src/Conjure/Representations/Relation/RelationAsSet.hs
+++ b/src/Conjure/Representations/Relation/RelationAsSet.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Common
 
 
 relationAsSet
-    :: forall m . (MonadFail m, NameGen m)
+    :: forall m . (MonadFail m,MonadFailDoc  m, NameGen m)
     => (forall x . DispatchFunction m x)
     -> (forall r x . ReprOptionsFunction m r x)
     -> Bool
@@ -115,14 +115,14 @@ relationAsSet dispatch reprOptions useLevels = Representation chck downD structu
                 Just (viewConstantSet -> Just tuples) -> do
                     vals <- mapM viewConstantTuple tuples
                     return (name, ConstantAbstract (AbsLitRelation vals))
-                Nothing -> fail $ vcat $
+                Nothing -> failDoc $ vcat $
                     [ "(in RelationAsSet up)"
                     , "No value for:" <+> pretty (outName domain name)
                     , "When working on:" <+> pretty name
                     , "With domain:" <+> pretty domain
                     ] ++
                     ("Bindings in context:" : prettyContext ctxt)
-                Just constant -> fail $ vcat $
+                Just constant -> failDoc $ vcat $
                     [ "Incompatible value for:" <+> pretty (outName domain name)
                     , "When working on:" <+> pretty name
                     , "With domain:" <+> pretty domain

--- a/src/Conjure/Representations/Sequence/ExplicitBounded.hs
+++ b/src/Conjure/Representations/Sequence/ExplicitBounded.hs
@@ -11,7 +11,6 @@ import Conjure.Representations.Common
 
 
 sequenceExplicitBounded :: forall m .
-    MonadFail m =>
     MonadFailDoc m=>
     NameGen m =>
     EnumerateDomain m =>

--- a/src/Conjure/Representations/Sequence/ExplicitBounded.hs
+++ b/src/Conjure/Representations/Sequence/ExplicitBounded.hs
@@ -12,6 +12,7 @@ import Conjure.Representations.Common
 
 sequenceExplicitBounded :: forall m .
     MonadFail m =>
+    MonadFailDoc m=>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -35,7 +36,7 @@ sequenceExplicitBounded = Representation chck downD structuralCons downC up symm
 
         getMaxSize (SizeAttr_MaxSize x) = return x
         getMaxSize (SizeAttr_MinMaxSize _ x) = return x
-        getMaxSize _ = fail "Unknown maxSize"
+        getMaxSize _ = failDoc "Unknown maxSize"
 
         downD :: TypeOf_DownD m
         downD (name, domain@(DomainSequence
@@ -229,7 +230,7 @@ sequenceExplicitBounded = Representation chck downD structuralCons downC up symm
             maxSizeInt <-
                 case maxSize of
                     ConstantInt _ x -> return x
-                    _ -> fail $ vcat
+                    _ -> failDoc $ vcat
                             [ "Expecting an integer for the maxSize attribute."
                             , "But got:" <+> pretty maxSize
                             , "When working on:" <+> pretty name
@@ -262,26 +263,26 @@ sequenceExplicitBounded = Representation chck downD structuralCons downC up symm
                             case viewConstantMatrix constantMatrix of
                                 Just (_, vals) ->
                                     return (name, ConstantAbstract (AbsLitSequence (genericTake card vals)))
-                                _ -> fail $ vcat
+                                _ -> failDoc $ vcat
                                         [ "Expecting a matrix literal for:" <+> pretty (nameValues domain name)
                                         , "But got:" <+> pretty constantMatrix
                                         , "When working on:" <+> pretty name
                                         , "With domain:" <+> pretty domain
                                         ]
-                        _ -> fail $ vcat
+                        _ -> failDoc $ vcat
                                 [ "Expecting an integer literal for:" <+> pretty (nameMarker domain name)
                                 , "But got:" <+> pretty marker
                                 , "When working on:" <+> pretty name
                                 , "With domain:" <+> pretty domain
                                 ]
-                (Nothing, _) -> fail $ vcat $
+                (Nothing, _) -> failDoc $ vcat $
                     [ "(in Sequence ExplicitBounded up 1)"
                     , "No value for:" <+> pretty (nameMarker domain name)
                     , "When working on:" <+> pretty name
                     , "With domain:" <+> pretty domain
                     ] ++
                     ("Bindings in context:" : prettyContext ctxt)
-                (_, Nothing) -> fail $ vcat $
+                (_, Nothing) -> failDoc $ vcat $
                     [ "(in Sequence ExplicitBounded up 2)"
                     , "No value for:" <+> pretty (nameValues domain name)
                     , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/Set/Explicit.hs
+++ b/src/Conjure/Representations/Set/Explicit.hs
@@ -8,7 +8,7 @@ import Conjure.Language
 import Conjure.Representations.Internal
 
 
-setExplicit :: forall m . (MonadFail m,MonadFailDoc m, NameGen m) => Representation m
+setExplicit :: forall m . (MonadFailDoc m, NameGen m) => Representation m
 setExplicit = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/Set/Explicit.hs
+++ b/src/Conjure/Representations/Set/Explicit.hs
@@ -8,7 +8,7 @@ import Conjure.Language
 import Conjure.Representations.Internal
 
 
-setExplicit :: forall m . (MonadFail m, NameGen m) => Representation m
+setExplicit :: forall m . (MonadFail m,MonadFailDoc m, NameGen m) => Representation m
 setExplicit = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -79,7 +79,7 @@ setExplicit = Representation chck downD structuralCons downC up symmetryOrdering
         up :: TypeOf_Up m
         up ctxt (name, domain@(DomainSet Set_Explicit (SetAttr (SizeAttr_Size _)) _)) =
             case lookup (outName domain name) ctxt of
-                Nothing -> fail $ vcat $
+                Nothing -> failDoc $ vcat $
                     [ "(in Set Explicit up)"
                     , "No value for:" <+> pretty (outName domain name)
                     , "When working on:" <+> pretty name
@@ -90,7 +90,7 @@ setExplicit = Representation chck downD structuralCons downC up symmetryOrdering
                     case viewConstantMatrix constant of
                         Just (_, vals) ->
                             return (name, ConstantAbstract (AbsLitSet vals))
-                        _ -> fail $ vcat
+                        _ -> failDoc $ vcat
                                 [ "Expecting a matrix literal for:" <+> pretty (outName domain name)
                                 , "But got:" <+> pretty constant
                                 , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/Set/ExplicitVarSizeWithDummy.hs
+++ b/src/Conjure/Representations/Set/ExplicitVarSizeWithDummy.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-setExplicitVarSizeWithDummy :: forall m . (MonadFail m,MonadFailDoc m, NameGen m) => Representation m
+setExplicitVarSizeWithDummy :: forall m . (MonadFailDoc m, NameGen m) => Representation m
 setExplicitVarSizeWithDummy = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/Set/ExplicitVarSizeWithDummy.hs
+++ b/src/Conjure/Representations/Set/ExplicitVarSizeWithDummy.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-setExplicitVarSizeWithDummy :: forall m . (MonadFail m, NameGen m) => Representation m
+setExplicitVarSizeWithDummy :: forall m . (MonadFail m,MonadFailDoc m, NameGen m) => Representation m
 setExplicitVarSizeWithDummy = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -128,7 +128,7 @@ setExplicitVarSizeWithDummy = Representation chck downD structuralCons downC up 
             maxSizeInt <-
                 case maxSize of
                     ConstantInt _ x -> return x
-                    _ -> fail $ vcat
+                    _ -> failDoc $ vcat
                             [ "Expecting an integer for the maxSize attribute."
                             , "But got:" <+> pretty maxSize
                             , "When working on:" <+> pretty name
@@ -148,7 +148,7 @@ setExplicitVarSizeWithDummy = Representation chck downD structuralCons downC up 
         up ctxt (name, domain@(DomainSet Set_ExplicitVarSizeWithDummy _ innerDomain)) = do
             let dummyElem = calcDummyElemC innerDomain
             case lookup (outName domain name) ctxt of
-                Nothing -> fail $ vcat $
+                Nothing -> failDoc $ vcat $
                     [ "(in Set ExplicitVarSizeWithDummy up)"
                     , "No value for:" <+> pretty (outName domain name)
                     , "When working on:" <+> pretty name
@@ -159,7 +159,7 @@ setExplicitVarSizeWithDummy = Representation chck downD structuralCons downC up 
                     case viewConstantMatrix constant of
                         Just (_, vals) ->
                             return (name, ConstantAbstract (AbsLitSet [ v | v <- vals, v /= dummyElem ]))
-                        _ -> fail $ vcat
+                        _ -> failDoc $ vcat
                                 [ "Expecting a matrix literal for:" <+> pretty (outName domain name)
                                 , "But got:" <+> pretty constant
                                 , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/Set/ExplicitVarSizeWithFlags.hs
+++ b/src/Conjure/Representations/Set/ExplicitVarSizeWithFlags.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-setExplicitVarSizeWithFlags :: forall m . (MonadFail m, NameGen m, EnumerateDomain m) => Representation m
+setExplicitVarSizeWithFlags :: forall m . (MonadFail m, MonadFailDoc  m, NameGen m, EnumerateDomain m) => Representation m
 setExplicitVarSizeWithFlags = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -112,7 +112,7 @@ setExplicitVarSizeWithFlags = Representation chck downD structuralCons downC up 
             maxSizeInt <-
                 case maxSize of
                     ConstantInt _ x -> return x
-                    _ -> fail $ vcat
+                    _ -> failDoc $ vcat
                             [ "Expecting an integer for the maxSize attribute."
                             , "But got:" <+> pretty maxSize
                             , "When working on:" <+> pretty name
@@ -158,26 +158,26 @@ setExplicitVarSizeWithFlags = Representation chck downD structuralCons downC up 
                                                     | (i,v) <- zip flags vals
                                                     , viewConstantBool i == Just True
                                                     ] )
-                                _ -> fail $ vcat
+                                _ -> failDoc $ vcat
                                         [ "Expecting a matrix literal for:" <+> pretty (nameValues domain name)
                                         , "But got:" <+> pretty constantMatrix
                                         , "When working on:" <+> pretty name
                                         , "With domain:" <+> pretty domain
                                         ]
-                        _ -> fail $ vcat
+                        _ -> failDoc $ vcat
                                 [ "Expecting a matrix literal for:" <+> pretty (nameFlag domain name)
                                 , "But got:" <+> pretty flagMatrix
                                 , "When working on:" <+> pretty name
                                 , "With domain:" <+> pretty domain
                                 ]
-                (Nothing, _) -> fail $ vcat $
+                (Nothing, _) -> failDoc $ vcat $
                     [ "(in Set ExplicitVarSizeWithFlags up 1)"
                     , "No value for:" <+> pretty (nameFlag domain name)
                     , "When working on:" <+> pretty name
                     , "With domain:" <+> pretty domain
                     ] ++
                     ("Bindings in context:" : prettyContext ctxt)
-                (_, Nothing) -> fail $ vcat $
+                (_, Nothing) -> failDoc $ vcat $
                     [ "(in Set ExplicitVarSizeWithFlags up 2)"
                     , "No value for:" <+> pretty (nameValues domain name)
                     , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/Set/ExplicitVarSizeWithFlags.hs
+++ b/src/Conjure/Representations/Set/ExplicitVarSizeWithFlags.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-setExplicitVarSizeWithFlags :: forall m . ( MonadFailDoc  m, NameGen m, EnumerateDomain m) => Representation m
+setExplicitVarSizeWithFlags :: forall m . (MonadFailDoc  m, NameGen m, EnumerateDomain m) => Representation m
 setExplicitVarSizeWithFlags = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/Set/ExplicitVarSizeWithFlags.hs
+++ b/src/Conjure/Representations/Set/ExplicitVarSizeWithFlags.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-setExplicitVarSizeWithFlags :: forall m . (MonadFail m, MonadFailDoc  m, NameGen m, EnumerateDomain m) => Representation m
+setExplicitVarSizeWithFlags :: forall m . ( MonadFailDoc  m, NameGen m, EnumerateDomain m) => Representation m
 setExplicitVarSizeWithFlags = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/Set/ExplicitVarSizeWithMarker.hs
+++ b/src/Conjure/Representations/Set/ExplicitVarSizeWithMarker.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-setExplicitVarSizeWithMarker :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
+setExplicitVarSizeWithMarker :: forall m . (MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
 setExplicitVarSizeWithMarker = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/Set/ExplicitVarSizeWithMarker.hs
+++ b/src/Conjure/Representations/Set/ExplicitVarSizeWithMarker.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-setExplicitVarSizeWithMarker :: forall m . (MonadFail m, NameGen m, EnumerateDomain m) => Representation m
+setExplicitVarSizeWithMarker :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
 setExplicitVarSizeWithMarker = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -100,7 +100,7 @@ setExplicitVarSizeWithMarker = Representation chck downD structuralCons downC up
             maxSizeInt <-
                 case maxSize of
                     ConstantInt _ x -> return x
-                    _ -> fail $ vcat
+                    _ -> failDoc $ vcat
                             [ "Expecting an integer for the maxSize attribute."
                             , "But got:" <+> pretty maxSize
                             , "When working on:" <+> pretty name
@@ -131,26 +131,26 @@ setExplicitVarSizeWithMarker = Representation chck downD structuralCons downC up
                                     return (name, ConstantAbstract (AbsLitSet (genericTake card vals)))
                                 (_, ConstantUndefined msg ty) ->         -- undefined propagates
                                     return (name, ConstantUndefined ("Set-ExplicitVarSizeWithMarker " `mappend` msg) ty)
-                                _ -> fail $ vcat
+                                _ -> failDoc $ vcat
                                         [ "Expecting a matrix literal for:" <+> pretty (nameValues domain name)
                                         , "But got:" <+> pretty constantMatrix
                                         , "When working on:" <+> pretty name
                                         , "With domain:" <+> pretty domain
                                         ]
-                        _ -> fail $ vcat
+                        _ -> failDoc $ vcat
                                 [ "Expecting an integer literal for:" <+> pretty (nameMarker domain name)
                                 , "But got:" <+> pretty marker
                                 , "When working on:" <+> pretty name
                                 , "With domain:" <+> pretty domain
                                 ]
-                (Nothing, _) -> fail $ vcat $
+                (Nothing, _) -> failDoc $ vcat $
                     [ "(in Set ExplicitVarSizeWithMarker up 1)"
                     , "No value for:" <+> pretty (nameMarker domain name)
                     , "When working on:" <+> pretty name
                     , "With domain:" <+> pretty domain
                     ] ++
                     ("Bindings in context:" : prettyContext ctxt)
-                (_, Nothing) -> fail $ vcat $
+                (_, Nothing) -> failDoc $ vcat $
                     [ "(in Set ExplicitVarSizeWithMarker up 2)"
                     , "No value for:" <+> pretty (nameValues domain name)
                     , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/Set/Occurrence.hs
+++ b/src/Conjure/Representations/Set/Occurrence.hs
@@ -9,7 +9,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-setOccurrence :: forall m . (MonadFail m, NameGen m) => Representation m
+setOccurrence :: forall m . (MonadFailDoc m,MonadFail m, NameGen m) => Representation m
 setOccurrence = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -71,13 +71,13 @@ setOccurrence = Representation chck downD structuralCons downC up symmetryOrderi
                                             | (v,b) <- zip innerDomainVals vals
                                             , viewConstantBool b == Just True
                                             ] )
-                        _ -> fail $ vcat
+                        _ -> failDoc $ vcat
                                 [ "Expecting a matrix literal for:" <+> pretty (outName domain name)
                                 , "But got:" <+> pretty constantMatrix
                                 , "When working on:" <+> pretty name
                                 , "With domain:" <+> pretty domain
                                 ]
-                Nothing -> fail $ vcat $
+                Nothing -> failDoc $ vcat $
                     [ "(in Set Occurrence up)"
                     , "No value for:" <+> pretty (outName domain name)
                     , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/Set/Occurrence.hs
+++ b/src/Conjure/Representations/Set/Occurrence.hs
@@ -9,7 +9,7 @@ import Conjure.Representations.Internal
 import Conjure.Representations.Common
 
 
-setOccurrence :: forall m . (MonadFailDoc m,MonadFail m, NameGen m) => Representation m
+setOccurrence :: forall m . (MonadFailDoc m, NameGen m) => Representation m
 setOccurrence = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/Tuple.hs
+++ b/src/Conjure/Representations/Tuple.hs
@@ -14,7 +14,7 @@ import Conjure.Representations.Internal
 import Data.Text ( pack )
 
 
-tuple :: forall m . (MonadFailDoc m, NameGen m) => Representation m
+tuple :: forall m . (MonadFailDoc m,MonadFail m, NameGen m) => Representation m
 tuple = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/Tuple.hs
+++ b/src/Conjure/Representations/Tuple.hs
@@ -14,7 +14,7 @@ import Conjure.Representations.Internal
 import Data.Text ( pack )
 
 
-tuple :: forall m . (MonadFailDoc m,MonadFail m, NameGen m) => Representation m
+tuple :: forall m . (MonadFailDoc m, NameGen m) => Representation m
 tuple = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/Tuple.hs
+++ b/src/Conjure/Representations/Tuple.hs
@@ -14,7 +14,7 @@ import Conjure.Representations.Internal
 import Data.Text ( pack )
 
 
-tuple :: forall m . (MonadFail m, NameGen m) => Representation m
+tuple :: forall m . (MonadFailDoc m, NameGen m) => Representation m
 tuple = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -66,7 +66,7 @@ tuple = Representation chck downD structuralCons downC up symmetryOrdering
             let names = map (mkName name) [1 .. length ds]
             vals <- forM names $ \ n ->
                 case lookup n ctxt of
-                    Nothing -> fail $ vcat $
+                    Nothing -> failDoc $ vcat $
                         [ "(in Tuple up)"
                         , "No value for:" <+> pretty n
                         , "When working on:" <+> pretty name

--- a/src/Conjure/Representations/Variant.hs
+++ b/src/Conjure/Representations/Variant.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Internal
 import Conjure.Language.ZeroVal ( EnumerateDomain, zeroVal )
 
 
-variant :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
+variant :: forall m . (MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
 variant = Representation chck downD structuralCons downC up symmetryOrdering
 
     where

--- a/src/Conjure/Representations/Variant.hs
+++ b/src/Conjure/Representations/Variant.hs
@@ -12,7 +12,7 @@ import Conjure.Representations.Internal
 import Conjure.Language.ZeroVal ( EnumerateDomain, zeroVal )
 
 
-variant :: forall m . (MonadFail m, NameGen m, EnumerateDomain m) => Representation m
+variant :: forall m . (MonadFail m,MonadFailDoc m, NameGen m, EnumerateDomain m) => Representation m
 variant = Representation chck downD structuralCons downC up symmetryOrdering
 
     where
@@ -92,21 +92,21 @@ variant = Representation chck downD structuralCons downC up symmetryOrdering
                         iName = mkName name iTag
                     in  case lookup iName ctxt of
                             Just val -> return (name, ConstantAbstract $ AbsLitVariant (Just dsForgotten) iTag val)
-                            Nothing -> fail $ vcat $
+                            Nothing -> failDoc $ vcat $
                                 [ "(in Variant up 1)"
                                 , "No value for:" <+> pretty iName
                                 , "When working on:" <+> pretty name
                                 , "With domain:" <+> pretty (DomainRecord ds)
                                 ] ++
                                 ("Bindings in context:" : prettyContext ctxt)
-                Nothing -> fail $ vcat $
+                Nothing -> failDoc $ vcat $
                     [ "(in Variant up 2)"
                     , "No value for:" <+> pretty (mkName name "_tag")
                     , "When working on:" <+> pretty name
                     , "With domain:" <+> pretty (DomainRecord ds)
                     ] ++
                     ("Bindings in context:" : prettyContext ctxt)
-                Just val -> fail $ vcat $
+                Just val -> failDoc $ vcat $
                     [ "Expecting an integer value for:" <+> pretty (mkName name "_tag")
                     , "When working on:" <+> pretty name
                     , "With domain:" <+> pretty (DomainRecord ds)

--- a/src/Conjure/Rules/Definition.hs
+++ b/src/Conjure/Rules/Definition.hs
@@ -157,10 +157,10 @@ data Rule = Rule
     { rName  :: Doc
     , rApply
         :: forall n m a .
-            ( MonadFail n,MonadFailDoc n, MonadUserError n, MonadLog n
+            ( MonadFailDoc n, MonadUserError n, MonadLog n
             , NameGen n, EnumerateDomain n, MonadReader (Zipper a Expression) n
                 -- a fail in {n} means that the rule isn't applicable
-            , MonadFail m,MonadFailDoc m, MonadUserError m, MonadLog m
+            , MonadFailDoc m, MonadUserError m, MonadLog m
             , NameGen m, EnumerateDomain m
                 -- a fail in {m} means a bug
             , ?typeCheckerMode :: TypeCheckerMode
@@ -173,9 +173,9 @@ data Rule = Rule
 namedRule
     :: Doc
     -> (forall n m a .
-            ( MonadFail n,MonadFailDoc n, MonadUserError n, MonadLog n
+            ( MonadFailDoc n, MonadUserError n, MonadLog n
             , NameGen n, EnumerateDomain n, MonadReader (Zipper a Expression) n
-            , MonadFail m, MonadFailDoc m, MonadUserError m, MonadLog m
+            ,  MonadFailDoc m, MonadUserError m, MonadLog m
             , NameGen m, EnumerateDomain m
             , ?typeCheckerMode :: TypeCheckerMode
             ) => Expression -> n (Doc, m Expression))
@@ -190,9 +190,9 @@ namedRule nm f = Rule
 namedRuleZ
     :: Doc
     -> (forall n m a .
-            ( MonadFail n,MonadFailDoc  n, MonadUserError n, MonadLog n
+            ( MonadFailDoc  n, MonadUserError n, MonadLog n
             , NameGen n, EnumerateDomain n, MonadReader (Zipper a Expression) n
-            , MonadFail m,MonadFailDoc m, MonadUserError m, MonadLog m
+            , MonadFailDoc m, MonadUserError m, MonadLog m
             , NameGen m, EnumerateDomain m
             , ?typeCheckerMode :: TypeCheckerMode
             ) => Zipper a Expression -> Expression -> n (Doc, m Expression))

--- a/src/Conjure/Rules/Definition.hs
+++ b/src/Conjure/Rules/Definition.hs
@@ -157,10 +157,10 @@ data Rule = Rule
     { rName  :: Doc
     , rApply
         :: forall n m a .
-            ( MonadFail n, MonadUserError n, MonadLog n
+            ( MonadFail n,MonadFailDoc n, MonadUserError n, MonadLog n
             , NameGen n, EnumerateDomain n, MonadReader (Zipper a Expression) n
                 -- a fail in {n} means that the rule isn't applicable
-            , MonadFail m, MonadUserError m, MonadLog m
+            , MonadFail m,MonadFailDoc m, MonadUserError m, MonadLog m
             , NameGen m, EnumerateDomain m
                 -- a fail in {m} means a bug
             , ?typeCheckerMode :: TypeCheckerMode
@@ -173,9 +173,9 @@ data Rule = Rule
 namedRule
     :: Doc
     -> (forall n m a .
-            ( MonadFail n, MonadUserError n, MonadLog n
+            ( MonadFail n,MonadFailDoc n, MonadUserError n, MonadLog n
             , NameGen n, EnumerateDomain n, MonadReader (Zipper a Expression) n
-            , MonadFail m, MonadUserError m, MonadLog m
+            , MonadFail m, MonadFailDoc m, MonadUserError m, MonadLog m
             , NameGen m, EnumerateDomain m
             , ?typeCheckerMode :: TypeCheckerMode
             ) => Expression -> n (Doc, m Expression))
@@ -190,9 +190,9 @@ namedRule nm f = Rule
 namedRuleZ
     :: Doc
     -> (forall n m a .
-            ( MonadFail n, MonadUserError n, MonadLog n
+            ( MonadFail n,MonadFailDoc  n, MonadUserError n, MonadLog n
             , NameGen n, EnumerateDomain n, MonadReader (Zipper a Expression) n
-            , MonadFail m, MonadUserError m, MonadLog m
+            , MonadFail m,MonadFailDoc m, MonadUserError m, MonadLog m
             , NameGen m, EnumerateDomain m
             , ?typeCheckerMode :: TypeCheckerMode
             ) => Zipper a Expression -> Expression -> n (Doc, m Expression))
@@ -211,7 +211,7 @@ isAtomic _ = False
 
 
 matchFirst
-    :: MonadFail m
+    :: MonadFailDoc m
     => [a]                  -- list of things to try matching on
     -> (a -> Maybe b)       -- the matcher
     -> m ( [a]              -- befores

--- a/src/Conjure/Rules/DontCare.hs
+++ b/src/Conjure/Rules/DontCare.hs
@@ -111,7 +111,6 @@ rule_Abstract = "dontCare-abstract" `namedRule` theRule where
 
 
 handleDontCares ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>

--- a/src/Conjure/Rules/DontCare.hs
+++ b/src/Conjure/Rules/DontCare.hs
@@ -112,6 +112,7 @@ rule_Abstract = "dontCare-abstract" `namedRule` theRule where
 
 handleDontCares ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -161,7 +162,7 @@ handleDontCares p =
                         _ -> bug ("dontCare on domain, expecting matrix, but got:" <+> pretty domX)
                 _ -> do
                     case representationOf x of
-                        Nothing -> fail "doesn't seem to have a representation, during handleDontCares"
+                        Nothing -> failDoc "doesn't seem to have a representation, during handleDontCares"
                         Just _  -> do
                             xs  <- downX1 x
                             xs' <- mapM (handleDontCares . make opDontCare) xs

--- a/src/Conjure/Rules/Import.hs
+++ b/src/Conjure/Rules/Import.hs
@@ -29,7 +29,7 @@ import Data.Generics.Uniplate.Zipper as Zipper ( Zipper, up, hole )
 -- when found, return whether this quantifier requires us to remove duplicates or not
 -- if none exists, do not apply the rule.
 -- (or maybe we should call bug right ahead, it can't be anything else.)
-doDuplicatesMatter :: MonadFail m => Zipper.Zipper a Expression -> m Bool
+doDuplicatesMatter :: MonadFailDoc m => Zipper.Zipper a Expression -> m Bool
 doDuplicatesMatter z0 =
     case Zipper.up z0 of
         Nothing -> na "doDuplicatesMatter 1"

--- a/src/Conjure/Rules/Transform.hs
+++ b/src/Conjure/Rules/Transform.hs
@@ -389,7 +389,7 @@ rule_Transform_Variant_Literal = "transform-variant-literal" `namedRule` theRule
      _ -> na "rule_Transform_Variant_Literal"
 
 
-atLeastOneTransform :: MonadFail m => (Expression, Expression) -> m ()
+atLeastOneTransform :: MonadFailDoc m => (Expression, Expression) -> m ()
 atLeastOneTransform (l,r) = do
   case (match opTransform l, match opTransform r) of
     (Nothing, Nothing) -> na "no transforms on either side"

--- a/src/Conjure/Rules/Vertical/Function/FunctionAsRelation.hs
+++ b/src/Conjure/Rules/Vertical/Function/FunctionAsRelation.hs
@@ -143,7 +143,7 @@ rule_InDefined = "function-inDefined{FunctionAsRelation}" `namedRule` theRule wh
     theRule _ = na "rule_InDefined"
 
     tableCheck ::
-        MonadFail m =>
+        MonadFailDoc m =>
         (?typeCheckerMode::TypeCheckerMode) =>
         Expression -> Expression -> m ()
     tableCheck x func | categoryOf func < CatDecision = do
@@ -180,7 +180,7 @@ rule_InToSet = "function-inToSet{FunctionAsRelation}" `namedRule` theRule where
     theRule _ = na "rule_InToSet"
 
     tableCheck ::
-        MonadFail m =>
+        MonadFailDoc m =>
         (?typeCheckerMode::TypeCheckerMode) =>
         Expression -> Expression -> m ()
     tableCheck x func | categoryOf func < CatDecision = do

--- a/src/Conjure/Rules/Vertical/Matrix.hs
+++ b/src/Conjure/Rules/Vertical/Matrix.hs
@@ -421,8 +421,8 @@ rule_Matrix_Lt_Primitive = "matrix-Lt-primitive" `namedRule` theRule where
                                 _ -> na "rule_Matrix_Lt_Primitive"
         tx <- typeOf x        -- TODO: check if x and y have the same arity
         ty <- typeOf y
-        unless (matrixNumDims tx > 0 && isPrimitiveType tx) $ fail ("not a primitive type:" <+> pretty tx)
-        unless (matrixNumDims ty > 0 && isPrimitiveType ty) $ fail ("not a primitive type:" <+> pretty ty)
+        unless (matrixNumDims tx > 0 && isPrimitiveType tx) $ failDoc ("not a primitive type:" <+> pretty tx)
+        unless (matrixNumDims ty > 0 && isPrimitiveType ty) $ failDoc ("not a primitive type:" <+> pretty ty)
         let x' = flattenIfNeeded (matrixNumDims tx) x
         let y' = flattenIfNeeded (matrixNumDims ty) y
         return
@@ -440,8 +440,8 @@ rule_Matrix_Leq_Primitive = "matrix-Leq-primitive" `namedRule` theRule where
                                 _ -> na "rule_Matrix_Leq_Primitive"
         tx <- typeOf x        -- TODO: check if x and y have the same arity
         ty <- typeOf y
-        unless (matrixNumDims tx > 0 && isPrimitiveType tx) $ fail ("not a primitive type:" <+> pretty tx)
-        unless (matrixNumDims ty > 0 && isPrimitiveType ty) $ fail ("not a primitive type:" <+> pretty ty)
+        unless (matrixNumDims tx > 0 && isPrimitiveType tx) $ failDoc ("not a primitive type:" <+> pretty tx)
+        unless (matrixNumDims ty > 0 && isPrimitiveType ty) $ failDoc ("not a primitive type:" <+> pretty ty)
         let x' = flattenIfNeeded (matrixNumDims tx) x
         let y' = flattenIfNeeded (matrixNumDims ty) y
         return
@@ -456,8 +456,8 @@ rule_Matrix_Lt_Decompose = "matrix-Lt-tuple" `namedRule` theRule where
         (x,y)           <- match opLt p
         tx@TypeMatrix{} <- typeOf x     -- TODO: check matrix index & tuple arity
         ty@TypeMatrix{} <- typeOf y
-        when (isPrimitiveType tx) $ fail ("this is a primitive type:" <+> pretty tx)
-        when (isPrimitiveType ty) $ fail ("this is a primitive type:" <+> pretty ty)
+        when (isPrimitiveType tx) $ failDoc ("this is a primitive type:" <+> pretty tx)
+        when (isPrimitiveType ty) $ failDoc ("this is a primitive type:" <+> pretty ty)
         xs              <- downX1 x
         ys              <- downX1 y
         return
@@ -472,8 +472,8 @@ rule_Matrix_Leq_Decompose = "matrix-Leq-tuple" `namedRule` theRule where
         (x,y)           <- match opLeq p
         tx@TypeMatrix{} <- typeOf x     -- TODO: check matrix index & tuple arity
         ty@TypeMatrix{} <- typeOf y
-        when (isPrimitiveType tx) $ fail ("this is a primitive type:" <+> pretty tx)
-        when (isPrimitiveType ty) $ fail ("this is a primitive type:" <+> pretty ty)
+        when (isPrimitiveType tx) $ failDoc ("this is a primitive type:" <+> pretty tx)
+        when (isPrimitiveType ty) $ failDoc ("this is a primitive type:" <+> pretty ty)
         xs              <- downX1 x
         ys              <- downX1 y
         return

--- a/src/Conjure/Rules/Vertical/Relation/RelationAsSet.hs
+++ b/src/Conjure/Rules/Vertical/Relation/RelationAsSet.hs
@@ -80,7 +80,7 @@ rule_In = "relation-in{RelationAsSet}" `namedRule` theRule where
     theRule _ = na "rule_In"
 
     tableCheck ::
-        MonadFail m =>
+        MonadFailDoc m =>
         (?typeCheckerMode::TypeCheckerMode) =>
         Expression -> Expression -> m ()
     tableCheck x rel | categoryOf rel < CatDecision = do

--- a/src/Conjure/Rules/Vertical/Set/Explicit.hs
+++ b/src/Conjure/Rules/Vertical/Set/Explicit.hs
@@ -140,7 +140,7 @@ rule_In = "set-in-table{Explicit}" `namedRule` theRule where
     theRule _ = na "rule_In"
 
     tableCheck ::
-        MonadFail m =>
+        MonadFailDoc m =>
         (?typeCheckerMode::TypeCheckerMode) =>
         Expression -> Expression -> m ()
     tableCheck x set | categoryOf set < CatDecision = do

--- a/src/Conjure/UI/IO.hs
+++ b/src/Conjure/UI/IO.hs
@@ -37,7 +37,7 @@ import qualified Data.ByteString.Char8 as BS ( putStrLn )
 
 readModelFromFile ::
     MonadIO m =>
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadUserError m =>
     FilePath -> m Model
 readModelFromFile fp = do
@@ -51,7 +51,7 @@ readModelFromFile fp = do
 
 readModelFromStdin ::
     MonadIO m =>
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadUserError m =>
     m Model
 readModelFromStdin = do
@@ -76,7 +76,7 @@ readParamJSON fp = do
 
 readParamOrSolutionFromFile ::
     MonadIO m =>
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadUserError m =>
     FilePath -> m Model
 readParamOrSolutionFromFile fp = do
@@ -93,7 +93,7 @@ readParamOrSolutionFromFile fp = do
 
 readModelPreambleFromFile ::
     MonadIO m =>
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadUserError m =>
     FilePath -> m Model
 readModelPreambleFromFile fp = do
@@ -106,7 +106,7 @@ readModelPreambleFromFile fp = do
 
 readModelInfoFromFile ::
     MonadIO m =>
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadUserError m =>
     FilePath -> m Model
 readModelInfoFromFile fp = do
@@ -119,7 +119,7 @@ readModelInfoFromFile fp = do
 
 
 readModel ::
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadUserError m =>
     Parser Model ->
     Maybe (Text -> Text) ->

--- a/src/Conjure/UI/MainHelper.hs
+++ b/src/Conjure/UI/MainHelper.hs
@@ -69,7 +69,6 @@ import Control.Concurrent.ParallelIO.Global ( parallel, parallel_, stopGlobalPoo
 mainWithArgs :: forall m .
     MonadIO m =>
     MonadLog m =>
-    MonadFail m =>
     MonadFailDoc m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -461,7 +460,6 @@ mainWithArgs config@Solve{..} = do
 mainWithArgs_Modelling :: forall m .
     MonadIO m =>
     MonadLog m =>
-    MonadFail m =>
     MonadFailDoc m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>

--- a/src/Conjure/UI/MainHelper.hs
+++ b/src/Conjure/UI/MainHelper.hs
@@ -70,6 +70,7 @@ mainWithArgs :: forall m .
     MonadIO m =>
     MonadLog m =>
     MonadFail m =>
+    MonadFailDoc m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
     UI -> m ()
@@ -461,6 +462,7 @@ mainWithArgs_Modelling :: forall m .
     MonadIO m =>
     MonadLog m =>
     MonadFail m =>
+    MonadFailDoc m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
     String ->                   -- modelNamePrefix

--- a/src/Conjure/UI/MainHelper.hs-boot
+++ b/src/Conjure/UI/MainHelper.hs-boot
@@ -9,7 +9,6 @@ import {-# SOURCE #-} Conjure.Process.Enumerate ( EnumerateDomain )
 mainWithArgs ::
     MonadIO m =>
     MonadLog m =>
-    MonadFail m =>
     MonadFailDoc m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>

--- a/src/Conjure/UI/MainHelper.hs-boot
+++ b/src/Conjure/UI/MainHelper.hs-boot
@@ -10,6 +10,7 @@ mainWithArgs ::
     MonadIO m =>
     MonadLog m =>
     MonadFail m =>
+    MonadFailDoc m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
     UI -> m ()

--- a/src/Conjure/UI/Model.hs
+++ b/src/Conjure/UI/Model.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Use camelCase" #-}
 
 module Conjure.UI.Model
     ( outputModels
@@ -130,6 +132,7 @@ outputModels ::
     forall m .
     MonadIO m =>
     MonadFail m =>
+    MonadFailDoc m =>
     MonadLog m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -262,6 +265,7 @@ outputModels portfolioSize modelHashesBefore modelNamePrefix config model = do
 toCompletion :: forall m .
     MonadIO m =>
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -298,6 +302,7 @@ toCompletion config m = do
 
 modelRepresentationsJSON ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     MonadLog m =>
@@ -327,6 +332,7 @@ modelRepresentationsJSON model = do
 
 modelRepresentations ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     MonadLog m =>
@@ -346,6 +352,7 @@ modelRepresentations model0 = do
 --   The whole model (containing P too) will be tried later for completeness.
 remainingWIP ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadLog m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -371,6 +378,7 @@ remainingWIP config wip@(TryThisFirst modelZipper info) = do
 
 remaining ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadLog m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -454,6 +462,7 @@ remaining config modelZipper minfo = do
 getQuestions ::
     MonadLog m =>
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -469,7 +478,7 @@ getQuestions config modelZipper | strategyQ config == PickFirst = maybeToList <$
                                    Nothing -> loopLevels as
                                    Just {} -> return bs
 
-        processLevel :: (MonadFail m, MonadLog m, NameGen m, EnumerateDomain m)
+        processLevel :: (MonadFailDoc m,MonadFail m , MonadLog m, NameGen m, EnumerateDomain m)
                      => [Rule]
                      -> m (Maybe (ModelZipper, [(Doc, RuleResult m)]))
         processLevel rulesAtLevel =
@@ -493,7 +502,7 @@ getQuestions config modelZipper =
                                    then loopLevels as
                                    else return bs
 
-        processLevel :: (MonadFail m, MonadLog m, NameGen m, EnumerateDomain m)
+        processLevel :: (MonadFail m,MonadFailDoc m, MonadLog m, NameGen m, EnumerateDomain m)
                      => [Rule]
                      -> m [(ModelZipper, [(Doc, RuleResult m)])]
         processLevel rulesAtLevel =
@@ -861,7 +870,7 @@ inlineDecVarLettings model =
 
 
 dropTagForSR ::
-    MonadFail m =>
+    MonadFailDoc m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
     Model -> m Model
 dropTagForSR m = do
@@ -897,7 +906,7 @@ dropTagForSR m = do
 
 updateDeclarations ::
     MonadUserError m =>
-    MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -1054,7 +1063,7 @@ checkIfHasUndefined m = return m
 
 
 topLevelBubbles ::
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadUserError m =>
     NameGen m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -1221,6 +1230,7 @@ logDebugIdModel msg a = logDebug (msg <++> pretty (a {mInfo = def})) >> return a
 
 prologue ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadLog m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -1256,6 +1266,7 @@ prologue model = do
 
 epilogue ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadLog m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -1282,6 +1293,8 @@ epilogue model = return model
 
 applicableRules :: forall m n .
     MonadUserError n =>
+    MonadFail n =>
+    MonadFailDoc n =>
     MonadLog n =>
     NameGen n =>
     EnumerateDomain n =>
@@ -1290,6 +1303,7 @@ applicableRules :: forall m n .
     NameGen m =>
     EnumerateDomain m =>
     MonadFail m =>
+    MonadFailDoc m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
     Config ->
     [Rule] ->
@@ -1734,6 +1748,7 @@ rule_ChooseRepr config = Rule "choose-repr" (const theRule) where
     mkHook
         :: ( MonadLog m
            , MonadFail m
+           , MonadFailDoc m
            , NameGen m
            , EnumerateDomain m
            )
@@ -1758,7 +1773,7 @@ rule_ChooseRepr config = Rule "choose-repr" (const theRule) where
 
             usedBefore = (name, reprTree domain) `elem` representationsTree
 
-            mkStructurals :: (MonadLog m, MonadFail m, NameGen m, EnumerateDomain m)
+            mkStructurals :: (MonadLog m,MonadFail m, MonadFailDoc m, NameGen m, EnumerateDomain m)
                           => m [Expression]
             mkStructurals = do
                 let ref = Reference name (Just (DeclHasRepr forg name domain))
@@ -1769,7 +1784,7 @@ rule_ChooseRepr config = Rule "choose-repr" (const theRule) where
                 logDebugVerbose $ "After  name resolution:" <+> vcat (map pretty resolved)
                 return resolved
 
-            addStructurals :: (MonadLog m, MonadFail m, NameGen m, EnumerateDomain m)
+            addStructurals :: (MonadLog m, MonadFail m,MonadFailDoc m, NameGen m, EnumerateDomain m)
                            => Model -> m Model
             addStructurals
                 | forg == Given = return
@@ -2330,7 +2345,7 @@ rule_DomainMinMax = "domain-MinMax" `namedRule` theRule where
             )
     theRule _ = na "rule_DomainMinMax"
 
-    getDomain :: MonadFail m => Expression -> m (Domain () Expression)
+    getDomain :: MonadFailDoc m => Expression -> m (Domain () Expression)
     getDomain (Domain d) = return d
     getDomain (Reference _ (Just (Alias (Domain d)))) = getDomain (Domain d)
     getDomain _ = na "rule_DomainMinMax.getDomain"
@@ -2547,7 +2562,7 @@ timedF name comp = \ a -> timeItNamed name (comp a)
 
 
 evaluateModel ::
-    MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>

--- a/src/Conjure/UI/Model.hs
+++ b/src/Conjure/UI/Model.hs
@@ -131,7 +131,6 @@ import qualified Data.Text as T ( stripPrefix )
 outputModels ::
     forall m .
     MonadIO m =>
-    MonadFail m =>
     MonadFailDoc m =>
     MonadLog m =>
     NameGen m =>
@@ -264,7 +263,6 @@ outputModels portfolioSize modelHashesBefore modelNamePrefix config model = do
 
 toCompletion :: forall m .
     MonadIO m =>
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -301,7 +299,6 @@ toCompletion config m = do
 
 
 modelRepresentationsJSON ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -331,7 +328,6 @@ modelRepresentationsJSON model = do
 
 
 modelRepresentations ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -351,7 +347,6 @@ modelRepresentations model0 = do
 --   and new rules will be tried using P as the top of the zipper-tree.
 --   The whole model (containing P too) will be tried later for completeness.
 remainingWIP ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadLog m =>
     NameGen m =>
@@ -377,7 +372,6 @@ remainingWIP config wip@(TryThisFirst modelZipper info) = do
 
 
 remaining ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadLog m =>
     NameGen m =>
@@ -461,7 +455,6 @@ remaining config modelZipper minfo = do
 --   strategyQ == PickFirst is special-cased for performance.
 getQuestions ::
     MonadLog m =>
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -478,7 +471,7 @@ getQuestions config modelZipper | strategyQ config == PickFirst = maybeToList <$
                                    Nothing -> loopLevels as
                                    Just {} -> return bs
 
-        processLevel :: (MonadFailDoc m,MonadFail m , MonadLog m, NameGen m, EnumerateDomain m)
+        processLevel :: (MonadFailDoc m, MonadLog m, NameGen m, EnumerateDomain m)
                      => [Rule]
                      -> m (Maybe (ModelZipper, [(Doc, RuleResult m)]))
         processLevel rulesAtLevel =
@@ -502,7 +495,7 @@ getQuestions config modelZipper =
                                    then loopLevels as
                                    else return bs
 
-        processLevel :: (MonadFail m,MonadFailDoc m, MonadLog m, NameGen m, EnumerateDomain m)
+        processLevel :: (MonadFailDoc m, MonadLog m, NameGen m, EnumerateDomain m)
                      => [Rule]
                      -> m [(ModelZipper, [(Doc, RuleResult m)])]
         processLevel rulesAtLevel =
@@ -979,7 +972,7 @@ updateDeclarations model = do
 
 
 -- | checking whether any `Reference`s with `DeclHasRepr`s are left in the model
-checkIfAllRefined :: MonadFail m => Model -> m Model
+checkIfAllRefined :: MonadFailDoc m => Model -> m Model
 checkIfAllRefined m | Just modelZipper <- mkModelZipper m = do             -- we exclude the mInfo here
     let returnMsg x = return
             $ ""
@@ -1044,7 +1037,7 @@ checkIfAllRefined m = return m
 
 
 -- | checking whether any undefined values creeped into the final model
-checkIfHasUndefined :: MonadFail m => Model -> m Model
+checkIfHasUndefined :: MonadFailDoc m => Model -> m Model
 checkIfHasUndefined m  | Just modelZipper <- mkModelZipper m = do
     let returnMsg x = return
             $ ""
@@ -1229,7 +1222,6 @@ logDebugIdModel :: MonadLog m => Doc -> Model -> m Model
 logDebugIdModel msg a = logDebug (msg <++> pretty (a {mInfo = def})) >> return a
 
 prologue ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadLog m =>
     NameGen m =>
@@ -1265,7 +1257,6 @@ prologue model = do
 
 
 epilogue ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadLog m =>
     NameGen m =>
@@ -1293,7 +1284,6 @@ epilogue model = return model
 
 applicableRules :: forall m n .
     MonadUserError n =>
-    MonadFail n =>
     MonadFailDoc n =>
     MonadLog n =>
     NameGen n =>
@@ -1302,7 +1292,6 @@ applicableRules :: forall m n .
     MonadLog m =>
     NameGen m =>
     EnumerateDomain m =>
-    MonadFail m =>
     MonadFailDoc m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
     Config ->
@@ -1773,7 +1762,7 @@ rule_ChooseRepr config = Rule "choose-repr" (const theRule) where
 
             usedBefore = (name, reprTree domain) `elem` representationsTree
 
-            mkStructurals :: (MonadLog m,MonadFail m, MonadFailDoc m, NameGen m, EnumerateDomain m)
+            mkStructurals :: (MonadLog m, MonadFailDoc m, NameGen m, EnumerateDomain m)
                           => m [Expression]
             mkStructurals = do
                 let ref = Reference name (Just (DeclHasRepr forg name domain))
@@ -1784,7 +1773,7 @@ rule_ChooseRepr config = Rule "choose-repr" (const theRule) where
                 logDebugVerbose $ "After  name resolution:" <+> vcat (map pretty resolved)
                 return resolved
 
-            addStructurals :: (MonadLog m, MonadFail m,MonadFailDoc m, NameGen m, EnumerateDomain m)
+            addStructurals :: (MonadLog m, MonadFailDoc m, NameGen m, EnumerateDomain m)
                            => Model -> m Model
             addStructurals
                 | forg == Given = return

--- a/src/Conjure/UI/ParameterGenerator.hs
+++ b/src/Conjure/UI/ParameterGenerator.hs
@@ -26,6 +26,7 @@ import Data.Text ( pack )
 --   (Just dropping wrong category stuff from attribute list isn't acceptable, because mset.)
 parameterGenerator ::
     MonadLog m =>
+    MonadFailDoc m =>
     MonadFail m =>
     MonadUserError m =>
     EnumerateDomain m =>

--- a/src/Conjure/UI/ParameterGenerator.hs
+++ b/src/Conjure/UI/ParameterGenerator.hs
@@ -27,7 +27,6 @@ import Data.Text ( pack )
 parameterGenerator ::
     MonadLog m =>
     MonadFailDoc m =>
-    MonadFail m =>
     MonadUserError m =>
     EnumerateDomain m =>
     NameGen m =>

--- a/src/Conjure/UI/TranslateParameter.hs
+++ b/src/Conjure/UI/TranslateParameter.hs
@@ -19,6 +19,7 @@ import Conjure.Representations ( downC )
 
 translateParameter ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadLog m =>
     NameGen m =>
     EnumerateDomain m =>

--- a/src/Conjure/UI/TranslateParameter.hs
+++ b/src/Conjure/UI/TranslateParameter.hs
@@ -18,7 +18,6 @@ import Conjure.Representations ( downC )
 
 
 translateParameter ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadLog m =>
     NameGen m =>

--- a/src/Conjure/UI/TranslateSolution.hs
+++ b/src/Conjure/UI/TranslateSolution.hs
@@ -21,7 +21,6 @@ import qualified Data.HashMap.Strict as M
 
 
 translateSolution ::
-    MonadFail m =>
     MonadFailDoc m =>
     MonadLog m =>
     NameGen m =>

--- a/src/Conjure/UI/TranslateSolution.hs
+++ b/src/Conjure/UI/TranslateSolution.hs
@@ -22,6 +22,7 @@ import qualified Data.HashMap.Strict as M
 
 translateSolution ::
     MonadFail m =>
+    MonadFailDoc m =>
     MonadLog m =>
     NameGen m =>
     EnumerateDomain m =>
@@ -101,7 +102,7 @@ translateSolution (undoUnderscores -> eprimeModel) (undoUnderscores -> essencePa
                           | i <- [1 .. size]
                           ]
                 in  Declaration (LettingDomainDefnEnum n nms)
-            _ -> fail $ vcat [ "Expecting an integer value for" <+> pretty n
+            _ -> failDoc $ vcat [ "Expecting an integer value for" <+> pretty n
                              , "But got:" <+> pretty s
                              ]
 

--- a/src/Conjure/UI/TypeCheck.hs
+++ b/src/Conjure/UI/TypeCheck.hs
@@ -183,7 +183,7 @@ typeCheckModel model1 = do
     -- now that everything knows its type, we can recover
     -- DomainInt [RangeSingle x] from DomainIntE x, if x has type int
     let
-        domainIntERecover :: forall m . Monad m => Domain () Expression -> m (Domain () Expression)
+        domainIntERecover :: forall m . MonadFailDoc m => Domain () Expression -> m (Domain () Expression)
         domainIntERecover d@(DomainIntE x) = do
             ty <- runExceptT $ typeOf x
             return $ case ty of

--- a/src/Conjure/UI/TypeCheck.hs
+++ b/src/Conjure/UI/TypeCheck.hs
@@ -22,7 +22,7 @@ import Conjure.Process.Sanity ( sanityChecks )
 
 
 typeCheckModel_StandAlone ::
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadUserError m =>
     MonadLog m =>
     NameGen m =>

--- a/src/Conjure/UI/ValidateSolution.hs
+++ b/src/Conjure/UI/ValidateSolution.hs
@@ -16,6 +16,7 @@ import Conjure.Process.ValidateConstantForDomain ( validateConstantForDomain )
 
 validateSolution ::
     MonadFail m =>
+    MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>
     (?typeCheckerMode :: TypeCheckerMode) =>
@@ -156,7 +157,7 @@ validateSolution essenceModel essenceParam essenceSolution = flip evalStateT [] 
 
 
 introduceRecordFields ::
-    MonadFail m =>
+    MonadFailDoc m =>
     MonadState [(Name, Expression)] m =>
     Pretty r =>
     Pretty x =>

--- a/src/Conjure/UI/ValidateSolution.hs
+++ b/src/Conjure/UI/ValidateSolution.hs
@@ -15,7 +15,6 @@ import Conjure.Process.ValidateConstantForDomain ( validateConstantForDomain )
 
 
 validateSolution ::
-    MonadFail m =>
     MonadFailDoc m =>
     NameGen m =>
     EnumerateDomain m =>

--- a/src/Conjure/UserError.hs
+++ b/src/Conjure/UserError.hs
@@ -4,15 +4,15 @@ module Conjure.UserError
     , failToUserError, failToBug
     ) where
 
-import Conjure.Prelude hiding ( fail )
-import qualified Conjure.Prelude as Prelude ( MonadFail(..) )
+import Conjure.Prelude 
+-- import qualified Conjure.Prelude as Prelude ( MonadFail(..) )
 import Conjure.Bug
 import Conjure.Language.Pretty
 
 -- base
 import System.Exit ( exitWith, ExitCode(..) )
 import System.IO as X ( stderr, hPutStrLn )
-import Control.Monad ( fail )
+
 
 -- pipes
 import qualified Pipes
@@ -88,8 +88,9 @@ instance (MonadFail m) => Monad (UserErrorT m) where
         case a of
             Left e -> return (Left e)
             Right x -> runUserErrorT (k x)
-    fail = lift . fail
 
+-- instance (MonadFailDoc m) => MonadFailDoc (UserErrorT m) where
+--     failDoc = lift . failDoc
 instance (MonadIO m, MonadFail m) => MonadIO (UserErrorT m) where
     liftIO comp = UserErrorT $ do
         res <- liftIO comp
@@ -101,7 +102,7 @@ instance MonadTrans UserErrorT where
         return (Right res)
 
 instance MonadFail m => MonadFail (UserErrorT m) where
-    fail = lift . Prelude.fail
+    fail = lift . fail
 
 instance MonadFail m => MonadUserError (UserErrorT m) where
     userErr msgs = UserErrorT $ return $ Left msgs

--- a/src/Conjure/UserError.hs
+++ b/src/Conjure/UserError.hs
@@ -101,6 +101,9 @@ instance MonadTrans UserErrorT where
         res <- comp
         return (Right res)
 
+instance (MonadFailDoc m, MonadFail m) => MonadFailDoc (UserErrorT m) where
+    failDoc = lift . failDoc
+
 instance MonadFail m => MonadFail (UserErrorT m) where
     fail = lift . fail
 

--- a/src/test/Conjure/Language/DomainSizeTest.hs
+++ b/src/test/Conjure/Language/DomainSizeTest.hs
@@ -12,7 +12,7 @@ import Test.Tasty ( TestTree, testGroup )
 import Test.Tasty.HUnit ( testCase, (@?=) )
 
 
-domainSizeConstant :: MonadFail m => Domain () Constant -> m Integer
+domainSizeConstant :: (MonadFail m,MonadFailDoc m ) => Domain () Constant -> m Integer
 domainSizeConstant = domainSizeOf
 
 tests :: TestTree

--- a/src/test/Conjure/Language/DomainSizeTest.hs
+++ b/src/test/Conjure/Language/DomainSizeTest.hs
@@ -12,7 +12,7 @@ import Test.Tasty ( TestTree, testGroup )
 import Test.Tasty.HUnit ( testCase, (@?=) )
 
 
-domainSizeConstant :: (MonadFail m,MonadFailDoc m ) => Domain () Constant -> m Integer
+domainSizeConstant :: (MonadFailDoc m ) => Domain () Constant -> m Integer
 domainSizeConstant = domainSizeOf
 
 tests :: TestTree


### PR DESCRIPTION
Part of the migration to later versions of ghc(>=8.8).

Fail as part of the Monad class was removed and added to a separate MonadFail class,[ see link](https://gitlab.haskell.org/haskell/prime/-/wikis/libraries/proposals/monad-fail). This causes conflicts with Conjure as it has a custom version of MonadFail implemented that is not compatible with the existing one. 

Changes:
- Renamed the existing MonadFail class to MonadFailDoc, denoting the fact that it operates with [Doc] rather than strings.
- Added MonadFail constraints to those functions which make use of failable pattern matches. 
-  Updated generator files to use the new Doc versions
- Removed the NoMonadFailDesugaring extension as it is no longer used.

Testing:
- [x] All tests pass
