### PR TITLE
Improve make solvers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,11 @@ solvers:
 	@echo ""
 	@echo "Set the environment variable PROCESSES to specify the number of cores to use. Default is 1."
 	@echo ""
-	@echo "Dependencies: cmake and gmp."
-	@if [ `uname` == "Darwin" ]; then echo "You can run: 'brew install cmake gmp' to install them."; fi
+	@echo "Dependencies: autoconf, cmake and gmp."
+	@if [ `uname` == "Darwin" ]; then echo "You can run: 'brew install autoconf cmake gmp' to install them."; fi
 	@echo ""
 	@mkdir -p ${BIN_DIR}
+	@rm -f make-solvers-*.stderr make-solvers-*.stdout > /dev/null 2> /dev/null
 	@etc/build/silent-wrapper.sh etc/build/install-bc_minisat_all.sh
 	@etc/build/silent-wrapper.sh etc/build/install-boolector.sh
 	@etc/build/silent-wrapper.sh etc/build/install-cadical.sh
@@ -138,4 +139,4 @@ solvers:
 	@etc/build/silent-wrapper.sh etc/build/install-open-wbo.sh
 	@etc/build/silent-wrapper.sh etc/build/install-yices.sh
 	@etc/build/silent-wrapper.sh etc/build/install-z3.sh
-	@if ls *.stderr *.stdout > /dev/null 2> /dev/null; then echo "At least one solver didn't build successfully."; exit 1; fi
+	@if ls make-solvers-*.stderr make-solvers-*.stdout > /dev/null 2> /dev/null; then echo "At least one solver didn't build successfully."; exit 1; fi

--- a/etc/build/silent-wrapper.sh
+++ b/etc/build/silent-wrapper.sh
@@ -12,23 +12,23 @@ echo "Running $1"
 
 PID=$$
 export STARTTIME=$(date +%s)
-bash $1 > ${PID}.stdout 2> ${PID}.stderr
+bash $1 > make-solvers-${PID}.stdout 2> make-solvers-${PID}.stderr
 EXITCODE=$?
 export ELAPSED=$(($(date +%s) - ${STARTTIME}))
 
 if [ ${EXITCODE} -eq 0 ] ; then
     echo "        Done (took ${ELAPSED} seconds)"
-    rm -f ${PID}.stdout ${PID}.stderr
+    rm -f make-solvers-${PID}.stdout make-solvers-${PID}.stderr
 else
     echo "        Failed (took ${ELAPSED} seconds)"
     echo "        Exit code: ${EXITCODE}"
-    echo "        Outputs saved to: ${PID}.stdout and ${PID}.stderr"
+    echo "        Outputs saved to: make-solvers-${PID}.stdout and make-solvers-${PID}.stderr"
     echo ""
     echo "Last 10 lines of the stdout was:"
-    tail -n10 ${PID}.stdout
+    tail -n10 make-solvers-${PID}.stdout
     echo ""
     echo "Last 10 lines of the stderr was:"
-    tail -n10 ${PID}.stderr
+    tail -n10 make-solvers-${PID}.stderr
     echo ""
     echo ""
     echo ""


### PR DESCRIPTION
1) autoconf is also listed as a dependecy.
2) use a more specialised naming scheme for the stderr and stdout files so they can be safely deleted.