### PR TITLE
Remove outdated information about supported GHC versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ clean:
 
 .PHONY: docs
 docs:
-	(cd docs; make conjure-help; make latexpdf; make singlehtml)
+	(cd docs; bash build.sh)
 
 .PHONY: ghci
 ghci:

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -2,5 +2,8 @@ rm -rf myenv
 python3 -m venv myenv
 source myenv/bin/activate
 pip install -r requirements.txt
+make conjure-help
 make html
+make singlehtml
+make latexpdf
 deactivate

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,12 +34,6 @@ It comes with a Makefile which will use Stack by default.
 The default target in the Makefile will install Stack using the standard procedures (which involves downloading and running a script).
 For more precise control, you might want to consider installing the Haskell tools beforehand instead of using the Makefile.
 
-Installation is known to work with
-`GHC-8.0.2 <http://www.haskell.org/ghc/download_ghc_8_0_2.html>`_,
-`GHC-8.2.2 <http://www.haskell.org/ghc/download_ghc_8_2_2.html>`_,
-`GHC-8.4.4 <http://www.haskell.org/ghc/download_ghc_8_4_4.html>`_, and
-`GHC-8.6.5 <http://www.haskell.org/ghc/download_ghc_8_6_5.html>`_.
-
 In addition, a number of supported backend solvers can be compiled using the `make solvers` target.
 This target also takes a BIN_DIR environment variable to control the location of the solver executables,
 and a PROCESSES environment variable to control how many processes to use when building solvers
@@ -52,26 +46,8 @@ Installing Savile Row
 ---------------------
 
 Since Conjure works by generating an Essence' model, Savile Row is a vital tool when using it.
-Savile Row can be downloaded from `its website <http://savilerow.cs.st-andrews.ac.uk>`_.
-
 You do not need to download Savile Row separately when you compile Conjure from source.
 An up-to-date version of Savile Row is also copied next to the Conjure executable.
 
+A standalone version of Savile Row and user documentation for Savile Row can be downloaded from `its website <http://savilerow.cs.st-andrews.ac.uk>`_.
 
-Compiling the documentation
----------------------------
-
-The Makefile target `docs` builds the manual in PDF and HTML format.
-This requires some Python packages to already be installed.
-With a recent Python 3 the following should work to install the needed Python dependencies:
-
-.. code-block:: bash
-
-    pip3 install sphinx-rtd-theme sphinxcontrib-bibtex
-
-Without specifying versions this currently installs Sphinx-5.x and recent versions of related dependencies.
-However, ``sphinx-rtd-theme`` forces ``opendoc < 0.18`` rather than a more recent version.
-Some packages used by ``sphinxcontrib-bibtex`` also seem to require an older version ``opendoc`` but do not explicitly declare this dependency, and just running ``pip3 install sphinxcontrib-bibtex`` will install packages which cannot successfully build the PDF documentation.
-
-The PDF target needs a fairly comprehensive TeX installation, with many styles and fonts beyond a minimal installation.
-The default packages installed by MacTeX should work on macOS.


### PR DESCRIPTION
Remove outdated information about supported GHC versions. Also repharase the SR text and remove the doc compilation section