### PR TITLE
Fixed or-tools install script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /conjure/
 # All binaries will end up in /root/.local/bin
 RUN mkdir -p /root/.local/bin
 ENV PATH /root/.local/bin:$PATH
+ENV LD_LIBRARY_PATH /root/.local/bin/lib:$LD_LIBRARY_PATH
 
 # Dependencies
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ RUN tests/allsolvers/test.sh
 FROM ubuntu:23.10
 WORKDIR /conjure
 ENV PATH /root/.local/bin:$PATH
+ENV LD_LIBRARY_PATH /root/.local/bin/lib:$LD_LIBRARY_PATH
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends default-jre-headless     # savilerow
 RUN mkdir -p /root/.local/bin/lib

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHELL := /bin/bash
 # override by calling the makefile like so: "GHC_VERSION=9.2 make"
 export GHC_VERSION?=9.4
 export BIN_DIR?=${HOME}/.local/bin
+export LIB_DIR?=${BIN_DIR}/lib
 export PATH := $(BIN_DIR):$(PATH)
 export CI?=false
 export BUILD_TESTS?=false
@@ -20,10 +21,15 @@ install:
 	@echo ""
 	@echo "Installing executables to ${BIN_DIR}"
 	@echo "Add this directory to your PATH."
-	@echo "Set the environment variable BIN_DIR to change this location"
-	@echo "For example: \"BIN_DIR=your/preferred/path make install\""
+	@echo ""
+	@echo "Installing shared libraries to ${LIB_DIR}"
+	@echo "Add this directory to your LD_LIBRARY_PATH."
+	@echo ""
+	@echo "You can set the environment variables BIN_DIR and LIB_DIR to change these locations"
+	@echo "For example: \"BIN_DIR=your/preferred/path LIB_DIR=/usr/local/lib make install\""
 	@echo ""
 	@mkdir -p ${BIN_DIR}
+	@mkdir -p ${LIB_DIR}
 	@echo Using Stack file: etc/hs-deps/stack-${GHC_VERSION}.yaml
 	@if ${BUILD_TESTS} ; then echo "BUILD_TESTS=true"; fi
 	@if ${CI} ; then echo "CI=true"; fi

--- a/etc/build/install-ortools.sh
+++ b/etc/build/install-ortools.sh
@@ -10,7 +10,10 @@ set -o errexit
 set -o nounset
 
 export BIN_DIR=${BIN_DIR:-${HOME}/.local/bin}
+export LIB_DIR=${LIB_DIR:-${BIN_DIR}/lib}
 export PROCESSES=${PROCESSES:-1}
+
+mkdir -p ${LIB_DIR}
 
 rm -rf tmp-install-ortools
 mkdir tmp-install-ortools

--- a/etc/build/install-ortools.sh
+++ b/etc/build/install-ortools.sh
@@ -22,7 +22,12 @@ cmake -S . -B build -DBUILD_DEPS=ON
 cmake --build build --config Release --target all -j${PROCESSES}
 cp build/bin/fzn-cp-sat ${BIN_DIR}/fzn-cp-sat
 # .dylib or .a depending on OS
-cp build/lib*/libortools* ${BIN_DIR}
+if test -z "${LD_LIBRARY_PATH}"; then
+    cp build/lib*/libortools* ${BIN_DIR}
+    echo "shared libraries path not found. Copying ortools librarites are in the ${BIN_DIR} folder. Please consider setting up a shared libraries folder"
+else
+    cp build/lib*/libortools* ${LD_LIBRARY_PATH}
+fi
 echo "ortools executable is at ${BIN_DIR}/fzn-cp-sat"
 ls -l ${BIN_DIR}/fzn-cp-sat
 popd

--- a/etc/build/install-ortools.sh
+++ b/etc/build/install-ortools.sh
@@ -22,12 +22,7 @@ cmake -S . -B build -DBUILD_DEPS=ON
 cmake --build build --config Release --target all -j${PROCESSES}
 cp build/bin/fzn-cp-sat ${BIN_DIR}/fzn-cp-sat
 # .dylib or .a depending on OS
-if test -z "${LD_LIBRARY_PATH}"; then
-    cp build/lib*/libortools* ${BIN_DIR}
-    echo "shared libraries path not found. Copying ortools librarites are in the ${BIN_DIR} folder. Please consider setting up a shared libraries folder"
-else
-    cp build/lib*/libortools* ${LD_LIBRARY_PATH}
-fi
+cp build/lib*/libortools* ${LIB_DIR}
 echo "ortools executable is at ${BIN_DIR}/fzn-cp-sat"
 ls -l ${BIN_DIR}/fzn-cp-sat
 popd

--- a/tests/allsolvers/run.sh
+++ b/tests/allsolvers/run.sh
@@ -33,11 +33,11 @@ echo ""
 echo ""
 echo "========================================"
 
-# echo "or-tools"
-# conjure solve test.essence --solver or-tools
-# echo ""
-# echo ""
-# echo "========================================"
+echo "or-tools"
+conjure solve test.essence --solver or-tools
+echo ""
+echo ""
+echo "========================================"
 
 # SAT solvers
 

--- a/tests/allsolvers/stdout.expected
+++ b/tests/allsolvers/stdout.expected
@@ -27,6 +27,15 @@ Copying solution to: test.solution
 
 
 ========================================
+or-tools
+Using cached models.
+Savile Row: model000001.eprime
+Running minion for domain filtering.
+Running solver: or-tools
+Copying solution to: test.solution
+
+
+========================================
 glucose
 Using cached models.
 Savile Row: model000001.eprime


### PR DESCRIPTION
Hi, I have noticed that, in some Linux systems, the script to install or-tools wasn't working properly: the compilation was successful but at, execution time, the Or-tools solver would throw an exception because it could not locate a shared library it needed. The library was present but it was located in the binary directory and not in the shared library directory. To fix this issue, I have added an if statement that checks if the shared binary folder is present and if it is, the libraries will be copied there. I have also added a message to inform the user on how to act in case the solver doesn't work.