### PR TITLE
Add gitignore template for Essence and Essence Prime

### DIFF
--- a/essence.gitignore
+++ b/essence.gitignore
@@ -1,0 +1,22 @@
+# .gitignore template for Essence and Essence'
+
+# Conjure
+conjure-output/
+
+# Savile Row
+*.aux
+
+*.eprime.minion
+*.eprime.info
+*.eprime.infor
+*.eprime.solution
+*.eprime.solution.*
+
+*.param.minion
+*.param.info
+*.param.infor
+*.param.solution
+*.param.solution.*
+
+# Minion
+.MINION*


### PR DESCRIPTION
Add a gitignore template for Essence and Essence Prime modelling, in the style of https://github.com/github/gitignore.

I could not find a good list of intermediate and output files for Conjure and Savile Row; having this in an easy to find place would be helpful.