### PR TITLE
build: update ubuntu base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # First stage: Building
 
 # Setting up
-FROM ubuntu:23.10 AS builder
+FROM ubuntu:24.10 AS builder
 ENV DEBIAN_FRONTEND noninteractive
 WORKDIR /conjure
 
@@ -81,7 +81,7 @@ RUN tests/allsolvers/test.sh
 ################################################################################
 # Second stage: Copying the binaries
 
-FROM ubuntu:23.10
+FROM ubuntu:24.10
 WORKDIR /conjure
 ENV PATH /root/.local/bin:$PATH
 ENV LD_LIBRARY_PATH /root/.local/bin/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
The originally used base image: 23.10, is no longer supported. This commit updates it to image version: 24.10 which is the most recent release and is supported until July 2025.