### PR TITLE
build: updated minizinc version from 2.8.3 to 2.8.5

### DIFF
--- a/etc/build/install-minizinc.sh
+++ b/etc/build/install-minizinc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# version as of 23 February 2024
-VERSION=2.8.3
+# version as of 3 June 2024
+VERSION=2.8.5
 set -o errexit
 set -o nounset
 


### PR DESCRIPTION
This is to have a consistent MiniZinc version across AutoIG and Conjure (AutoIG uses 2.8.5 which was released on 3 June 2024).