### PR TITLE
Add support for downloading stack on arm macs

### DIFF
--- a/etc/build/install-stack.sh
+++ b/etc/build/install-stack.sh
@@ -10,7 +10,11 @@ export CI=${CI:-false}
 
 function dlStack {
     if [ `uname` = "Darwin" ] ; then
-        curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ${BIN_DIR}
+        if [[ $(uname -m) == 'arm64' ]]; then
+            curl --insecure -L https://get.haskellstack.org/stable/osx-aarch64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ${BIN_DIR}
+        else
+            curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ${BIN_DIR}
+        fi
     elif [ `uname` = "Linux" ] ; then
         curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ${BIN_DIR} '*/stack'
     else


### PR DESCRIPTION
This just adds auto-downloading of stack for ARM macs. Tested on an arm mac, hopefully I didn't break intel ones!

The place where stack is normally downloaded from doesn't have arm -- I don't know if it's sensible to move over to https://get.haskellstack.org/stable/ for other OSes. For information, this downloads:

```Version 3.3.1, Git revision 7540878295db1899b55855cc765ab1eacdf30f3c aarch64 hpack-0.37.0```