### PR TITLE
Add shebangs to container executables in docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,7 +30,7 @@ Docker
     mkdir -p ~/.local/bin
 
     # create the conjure wrapper
-    printf '#!/bin/sh\ndocker run --rm -v "$PWD:/work" -w /work ghcr.io/conjure-cp/conjure:v2.6.0 conjure "$@"' > ~/.local/bin/conjure
+    printf '#!/bin/sh\ndocker run --rm -v "$PWD:/work" -w /work ghcr.io/conjure-cp/conjure:v2.6.0 conjure "$@"\n' > ~/.local/bin/conjure
 
     # make it executable
     chmod +x ~/.local/bin/conjure


### PR DESCRIPTION
Currently, conjure-oxide cannot run the containerised `conjure` one-liner executable, due to a lack of shebang. Adding shebangs to the installation commands fixes this issue.
